### PR TITLE
feat(events): Add priceString property for complex price structures

### DIFF
--- a/src/events/dto/create-event.dto.ts
+++ b/src/events/dto/create-event.dto.ts
@@ -39,7 +39,11 @@ export class CreateEventDto {
 
   @IsOptional()
   @IsNumber()
-  public readonly price?: number;
+  public readonly price?: number | null;
+
+  @IsOptional()
+  @IsString()
+  public readonly priceString?: string;
 
   @IsString()
   @IsNotEmpty()

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -140,6 +140,7 @@ export class EventsService {
         titleImageUrl: '',
         ticketsNeeded: data.ticketsNeeded || false,
         price: data.price || 0,
+        priceString: data.priceString,
         categoryId: data.categoryId,
         contactEmail: data.contactEmail || '',
         contactPhone: data.contactPhone || '',

--- a/src/events/interfaces/event.interface.ts
+++ b/src/events/interfaces/event.interface.ts
@@ -39,7 +39,17 @@ export interface Event {
   updatedAt: string;
   favoriteCount?: number;
   ticketsNeeded?: boolean;
-  price?: number;
+  /**
+   * @deprecated
+   * Preis als Zahl (für Rückwärtskompatibilität mit der App)
+   * Die App erwartet ausschließlich Zahlen oder null
+   */
+  price?: number | null;
+  /**
+   * Preis als String für komplexe Preisstrukturen (z.B. "ab 10,00€", "Kostenlos", "15,00€ - 25,00€")
+   * Wenn vorhanden, sollte dieser Wert für die Anzeige verwendet werden
+   */
+  priceString?: string;
   categoryId: string;
   contactEmail?: string;
   contactPhone?: string;


### PR DESCRIPTION
- Add priceString?: string to Event interface for flexible price display (e.g. 'ab 10,00€', 'Kostenlos')
- Mark price as deprecated but keep for backward compatibility with app
- Update CreateEventDto to accept both price (number) and priceString (string)
- Update EventsService to handle both properties
- App remains compatible as it expects price as number | null