### PR TITLE
Feature/scraping analysis improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ WALLET_SIGNER_CERT=...
 WALLET_KEY_PASSPHRASE=...
 ```
 
+### Mistral AI API (für LLM-basierte Event-Extraktion)
+```
+MISTRAL_API_KEY=your_mistral_api_key_here
+MISTRAL_BASE_URL=https://api.mistral.ai/v1  # Optional, Standard: Mistral API
+# Alternative: DeepInfra
+# MISTRAL_BASE_URL=https://api.deepinfra.com/v1/openai
+```
+
 ### Umgebungskonfiguration
 ```
 NODE_ENV=development|test|production
@@ -98,6 +106,8 @@ docker buildx build --platform linux/amd64 \
     -e PORT=3000 \
     -e NODE_ENV=dev \
     -e BASE_URL=/dev \
+    -e MISTRAL_API_KEY=${MISTRAL_API_KEY} \
+    -e MISTRAL_BASE_URL=https://api.mistral.ai/v1 \
     dengelma/nuernbergspots-test`
 
 ### Produktionsumgebung (nuernbergspots.de/prd)
@@ -109,6 +119,8 @@ docker buildx build --platform linux/amd64 \
     -e PORT=3100 \
     -e NODE_ENV=prd \
     -e BASE_URL=/prd \
+    -e MISTRAL_API_KEY=${MISTRAL_API_KEY} \
+    -e MISTRAL_BASE_URL=https://api.mistral.ai/v1 \
     dengelma/nuernbergspots`
 
 ## Umgebungsvariablen in Docker
@@ -119,8 +131,12 @@ Die folgenden Umgebungsvariablen können beim Start des Containers übergeben we
 - `PORT`: Der Port, auf dem die Anwendung läuft (3000 für Test, 3100 für Produktion)
 - `ENV_FILE`: Die zu verwendende .env-Datei (.env für Test, .env.prod für Produktion)
 - `BASE_URL`: Der Base-Path der API (/dev für Test, /prd für Produktion)
+- `MISTRAL_API_KEY`: Mistral API Key für LLM-basierte Event-Extraktion (erforderlich)
+- `MISTRAL_BASE_URL`: Mistral API Base URL (optional, Standard: https://api.mistral.ai/v1)
 
 Alle anderen Umgebungsvariablen werden aus der angegebenen .env-Datei geladen.
+
+**WICHTIG:** Für Details zur Mistral API Token-Integration siehe [docs/mistral-api-setup.md](docs/mistral-api-setup.md)
 
 ## Check container logs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,7 @@ services:
       - FIREBASE_APP_ID=${FIREBASE_APP_ID}
       # HERE Maps API Credentials
       - HERE_APP_ID=${HERE_APP_ID}
-      - HERE_API_KEY=${HERE_API_KEY} 
+      - HERE_API_KEY=${HERE_API_KEY}
+      # Mistral AI API
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+      - MISTRAL_BASE_URL=${MISTRAL_BASE_URL:-https://api.mistral.ai/v1} 

--- a/docs/api-llm-scraping.md
+++ b/docs/api-llm-scraping.md
@@ -1,0 +1,273 @@
+# LLM-basierte Event-Extraktion - API-Dokumentation
+
+## Übersicht
+
+Die LLM-basierte Event-Extraktion nutzt Mistral Small 3.2 für semantische Extraktion von Events aus HTML-Seiten. Bei Fehlern oder leeren Ergebnissen erfolgt automatisch ein Fallback zu den bestehenden Puppeteer-Scrapers.
+
+## Endpoints
+
+### 1. Events von URL extrahieren
+
+**POST** `/events/scrape/llm`
+
+Extrahiert Events von einer beliebigen URL mit LLM-basierter Extraktion.
+
+#### Request Body
+
+```json
+{
+  "url": "https://eventfinder.de/nuernberg",
+  "useFallback": true
+}
+```
+
+**Parameter:**
+- `url` (string, erforderlich): Die URL der Seite, von der Events extrahiert werden sollen
+- `useFallback` (boolean, optional): Ob bei Fehlern auf Puppeteer-Scraper zurückgegriffen werden soll (Standard: `true`)
+
+#### Response
+
+```json
+{
+  "events": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "title": "Konzert im Park",
+      "description": "Open-Air Konzert mit lokalen Bands",
+      "location": {
+        "address": "Wöhrder Wiese, Nürnberg",
+        "latitude": 49.45,
+        "longitude": 11.08
+      },
+      "dailyTimeSlots": [
+        {
+          "date": "2026-01-15",
+          "from": "19:00",
+          "to": "22:00"
+        }
+      ],
+      "price": 15,
+      "priceString": "15,00€",
+      "categoryId": "konzert",
+      "titleImageUrl": "https://example.com/image.jpg",
+      "imageUrls": ["https://example.com/image1.jpg"],
+      "website": "https://example.com/event",
+      "createdAt": "2026-01-09T10:00:00.000Z",
+      "updatedAt": "2026-01-09T10:00:00.000Z"
+    }
+  ],
+  "hasMorePages": false
+}
+```
+
+**Response-Felder:**
+- `events` (Event[]): Array von extrahierten Events
+- `hasMorePages` (boolean): Gibt an, ob weitere Seiten verfügbar sind (aktuell immer `false`)
+- `nextPageUrl` (string, optional): URL der nächsten Seite (aktuell nicht verwendet)
+
+#### Fehlerbehandlung
+
+**400 Bad Request:**
+```json
+{
+  "statusCode": 400,
+  "message": "URL ist erforderlich"
+}
+```
+
+**500 Internal Server Error:**
+Bei Fehlern in der LLM-Extraktion wird automatisch auf Puppeteer-Fallback zurückgegriffen (falls `useFallback: true`). Falls auch dieser fehlschlägt, wird ein Fehler zurückgegeben.
+
+### 2. Kosten-Statistiken abrufen
+
+**GET** `/events/scrape/llm/costs`
+
+Gibt die monatlichen Kosten für LLM-Extraktion zurück.
+
+#### Response
+
+```json
+{
+  "mistral-small-latest": 0.15
+}
+```
+
+**Response-Felder:**
+- Schlüssel: Modell-Name (z.B. `mistral-small-latest`)
+- Wert: Gesamtkosten in USD für den aktuellen Monat
+
+### 3. Token-Verbrauch abrufen
+
+**GET** `/events/scrape/llm/tokens`
+
+Gibt den Token-Verbrauch für LLM-Extraktion zurück.
+
+#### Response
+
+```json
+{
+  "mistral-small-latest": {
+    "input": 500000,
+    "output": 100000
+  }
+}
+```
+
+**Response-Felder:**
+- Schlüssel: Modell-Name
+- `input`: Anzahl der Input-Tokens
+- `output`: Anzahl der Output-Tokens
+
+## Beispiel-Integrationen
+
+### cURL
+
+```bash
+# Events extrahieren
+curl -X POST http://localhost:3000/events/scrape/llm \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN" \
+  -d '{
+    "url": "https://eventfinder.de/nuernberg",
+    "useFallback": true
+  }'
+
+# Kosten abrufen
+curl -X GET http://localhost:3000/events/scrape/llm/costs \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN"
+
+# Token-Verbrauch abrufen
+curl -X GET http://localhost:3000/events/scrape/llm/tokens \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN"
+```
+
+### JavaScript/TypeScript (Fetch API)
+
+```typescript
+async function scrapeEventsWithLlm(url: string, useFallback = true) {
+  const response = await fetch('http://localhost:3000/events/scrape/llm', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${firebaseToken}`,
+    },
+    body: JSON.stringify({
+      url,
+      useFallback,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const result = await response.json();
+  return result.events;
+}
+
+// Verwendung
+const events = await scrapeEventsWithLlm('https://eventfinder.de/nuernberg');
+console.log(`Gefunden: ${events.length} Events`);
+```
+
+### JavaScript/TypeScript (Axios)
+
+```typescript
+import axios from 'axios';
+
+async function scrapeEventsWithLlm(url: string, useFallback = true) {
+  const response = await axios.post(
+    'http://localhost:3000/events/scrape/llm',
+    {
+      url,
+      useFallback,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${firebaseToken}`,
+      },
+    },
+  );
+
+  return response.data.events;
+}
+
+// Kosten abrufen
+async function getLlmCosts() {
+  const response = await axios.get('http://localhost:3000/events/scrape/llm/costs', {
+    headers: {
+      Authorization: `Bearer ${firebaseToken}`,
+    },
+  });
+
+  return response.data;
+}
+```
+
+## Authentifizierung
+
+**WICHTIG:** Alle Endpoints erfordern eine Firebase-Authentifizierung.
+
+Der `Authorization`-Header muss ein gültiges Firebase-ID-Token enthalten:
+
+```
+Authorization: Bearer <firebase-id-token>
+```
+
+## Verhalten
+
+### LLM-Extraktion (Primär)
+
+1. HTML-Inhalt wird von der angegebenen URL geladen
+2. HTML wird bereinigt (Scripts, Styles, Kommentare entfernt)
+3. Mistral Small 3.2 extrahiert Events semantisch aus dem HTML
+4. Events werden normalisiert (IDs, Timestamps hinzugefügt)
+5. Ergebnis wird zurückgegeben
+
+### Puppeteer-Fallback
+
+Der Fallback wird aktiviert, wenn:
+- LLM-Extraktion einen Fehler wirft
+- LLM-Extraktion keine Events findet
+- `useFallback: true` gesetzt ist (Standard)
+
+Der Fallback versucht automatisch, den passenden Puppeteer-Scraper basierend auf der Domain zu identifizieren:
+- `eventfinder.de` → EventFinderScraper
+- `curt.de` → CurtScraper
+- `rausgegangen.de` → RausgegangenScraper
+- `eventbrite.de` / `eventbrite.com` → EventbriteScraper
+
+## Kosten
+
+Die Kosten werden automatisch getrackt:
+- **Mistral Small 3.2:** $0.075 pro 1M Input-Tokens, $0.2 pro 1M Output-Tokens
+- Bei realistischer Nutzung (50 Seiten/Woche): ~$0.15-0.30 pro Monat
+
+Kosten können über `/events/scrape/llm/costs` abgerufen werden.
+
+## Rate Limits
+
+- Mistral API: Standard-Rate-Limits der Mistral API
+- Puppeteer-Fallback: Keine Limits (lokale Ausführung)
+
+## Best Practices
+
+1. **URL-Validierung:** Stellen Sie sicher, dass die URL gültig und erreichbar ist
+2. **Error-Handling:** Implementieren Sie Retry-Logik für temporäre Fehler
+3. **Kosten-Monitoring:** Überwachen Sie regelmäßig die Kosten über `/events/scrape/llm/costs`
+4. **Fallback nutzen:** Lassen Sie `useFallback: true` aktiviert für maximale Zuverlässigkeit
+5. **Batch-Processing:** Für mehrere URLs, rufen Sie den Endpoint sequenziell auf (keine Batch-API vorhanden)
+
+## Bekannte Einschränkungen
+
+- Keine Batch-API für mehrere URLs gleichzeitig
+- `hasMorePages` ist aktuell immer `false` (Pagination nicht implementiert)
+- Geocoding von Adressen zu Koordinaten erfolgt nicht automatisch (latitude/longitude können 0 sein)
+- Kategorien werden auf bekannte Werte validiert, unbekannte werden zu `default` gemappt
+
+## Support
+
+Bei Fragen oder Problemen:
+1. Prüfen Sie die Logs für detaillierte Fehlermeldungen
+2. Überprüfen Sie die Kosten- und Token-Statistiken
+3. Testen Sie mit `useFallback: false` um LLM-spezifische Fehler zu isolieren

--- a/docs/api-llm-scraping.md
+++ b/docs/api-llm-scraping.md
@@ -88,13 +88,29 @@ Gibt die monatlichen Kosten für LLM-Extraktion zurück.
 
 ```json
 {
-  "mistral-small-latest": 0.15
+  "costs": {
+    "mistral-small-latest": 0.15
+  },
+  "total": 0.15,
+  "currency": "USD"
 }
 ```
 
 **Response-Felder:**
-- Schlüssel: Modell-Name (z.B. `mistral-small-latest`)
-- Wert: Gesamtkosten in USD für den aktuellen Monat
+- `costs` (object): Kosten pro Modell in USD
+  - Schlüssel: Modell-Name (z.B. `mistral-small-latest`)
+  - Wert: Gesamtkosten in USD für den aktuellen Monat
+- `total` (number): Gesamtkosten aller Modelle in USD
+- `currency` (string): Währung (immer "USD")
+
+**Hinweis:** Daten werden im Memory gespeichert und gehen bei Neustart des Servers verloren. Bei leerem Zustand:
+```json
+{
+  "costs": {},
+  "total": 0,
+  "currency": "USD"
+}
+```
 
 ### 3. Token-Verbrauch abrufen
 
@@ -106,17 +122,43 @@ Gibt den Token-Verbrauch für LLM-Extraktion zurück.
 
 ```json
 {
-  "mistral-small-latest": {
+  "usage": {
+    "mistral-small-latest": {
+      "input": 500000,
+      "output": 100000,
+      "total": 600000
+    }
+  },
+  "totals": {
     "input": 500000,
-    "output": 100000
+    "output": 100000,
+    "total": 600000
   }
 }
 ```
 
 **Response-Felder:**
-- Schlüssel: Modell-Name
-- `input`: Anzahl der Input-Tokens
-- `output`: Anzahl der Output-Tokens
+- `usage` (object): Token-Verbrauch pro Modell
+  - Schlüssel: Modell-Name
+  - `input`: Anzahl der Input-Tokens
+  - `output`: Anzahl der Output-Tokens
+  - `total`: Gesamt-Tokens (input + output)
+- `totals` (object): Gesamtsummen aller Modelle
+  - `input`: Gesamt Input-Tokens
+  - `output`: Gesamt Output-Tokens
+  - `total`: Gesamt-Tokens
+
+**Hinweis:** Daten werden im Memory gespeichert und gehen bei Neustart des Servers verloren. Bei leerem Zustand:
+```json
+{
+  "usage": {},
+  "totals": {
+    "input": 0,
+    "output": 0,
+    "total": 0
+  }
+}
+```
 
 ## Beispiel-Integrationen
 

--- a/docs/mistral-api-setup.md
+++ b/docs/mistral-api-setup.md
@@ -1,0 +1,307 @@
+# Mistral API Token Setup & Integration
+
+## 1. Mistral API Token erhalten
+
+### Schritt 1: Account erstellen
+
+1. Gehen Sie zu [https://console.mistral.ai/](https://console.mistral.ai/)
+2. Erstellen Sie ein kostenloses Konto oder loggen Sie sich ein
+3. Bestätigen Sie Ihre E-Mail-Adresse
+
+### Schritt 2: API Key generieren
+
+1. Navigieren Sie zu **API Keys** im Dashboard
+2. Klicken Sie auf **"Create API Key"**
+3. Geben Sie einen Namen ein (z.B. "citylife-backend-production")
+4. Kopieren Sie den generierten API Key **sofort** - er wird nur einmal angezeigt!
+
+**WICHTIG:** Der API Key beginnt mit `mistral-` und sieht etwa so aus:
+```
+mistral-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+### Schritt 3: Billing einrichten (optional)
+
+- Für Produktionsumgebungen sollten Sie ein Billing-Konto einrichten
+- Mistral bietet ein kostenloses Kontingent, danach Pay-as-you-go
+- Überwachen Sie die Nutzung im Dashboard
+
+### Alternative: DeepInfra
+
+Falls Sie DeepInfra als Alternative nutzen möchten:
+
+1. Gehen Sie zu [https://deepinfra.com/](https://deepinfra.com/)
+2. Erstellen Sie ein Konto
+3. Generieren Sie einen API Key
+4. Nutzen Sie `MISTRAL_BASE_URL=https://api.deepinfra.com/v1/openai`
+
+## 2. Lokale Entwicklung
+
+### .env Datei erstellen/bearbeiten
+
+Erstellen Sie eine `.env` Datei im Projekt-Root (falls nicht vorhanden):
+
+```bash
+# Mistral AI API
+MISTRAL_API_KEY=mistral-your-api-key-here
+MISTRAL_BASE_URL=https://api.mistral.ai/v1  # Optional, Standard-Wert
+```
+
+**WICHTIG:** Fügen Sie `.env` zu `.gitignore` hinzu, damit der API Key nicht ins Repository gelangt!
+
+### Testen der Konfiguration
+
+```bash
+# Starten Sie die Anwendung
+npm run start:dev
+
+# Testen Sie den Endpoint
+curl -X POST http://localhost:3000/events/scrape/llm \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN" \
+  -d '{"url": "https://eventfinder.de/nuernberg"}'
+```
+
+## 3. Docker Compose (Lokale Entwicklung)
+
+### .env Datei für Docker
+
+Die `.env` Datei wird automatisch von Docker Compose geladen:
+
+```bash
+# In docker-compose.yml wird bereits env_file verwendet
+ENV_FILE=.env docker-compose up
+```
+
+Stellen Sie sicher, dass `MISTRAL_API_KEY` in Ihrer `.env` Datei vorhanden ist.
+
+## 4. Docker Build & Deployment
+
+### Option A: Environment-Variablen beim Docker Run
+
+**Test-Umgebung:**
+```bash
+docker run -d --name nuernbergspots-test -p 3000:3000 --restart unless-stopped \
+  -e PORT=3000 \
+  -e NODE_ENV=dev \
+  -e BASE_URL=/dev \
+  -e MISTRAL_API_KEY=mistral-your-api-key-here \
+  -e MISTRAL_BASE_URL=https://api.mistral.ai/v1 \
+  dengelma/nuernbergspots-test
+```
+
+**Produktionsumgebung:**
+```bash
+docker run -d --name nuernbergspots -p 3100:3100 --restart unless-stopped \
+  -e PORT=3100 \
+  -e NODE_ENV=prd \
+  -e BASE_URL=/prd \
+  -e MISTRAL_API_KEY=mistral-your-production-api-key-here \
+  -e MISTRAL_BASE_URL=https://api.mistral.ai/v1 \
+  dengelma/nuernbergspots
+```
+
+### Option B: .env Datei auf dem Server
+
+**Sicherer:** Erstellen Sie eine `.env.prod` Datei auf dem Server:
+
+```bash
+# Auf dem Server (z.B. /root/citylife-backend/.env.prod)
+MISTRAL_API_KEY=mistral-your-production-api-key-here
+MISTRAL_BASE_URL=https://api.mistral.ai/v1
+```
+
+Dann beim Docker Run:
+```bash
+docker run -d --name nuernbergspots -p 3100:3100 --restart unless-stopped \
+  --env-file /root/citylife-backend/.env.prod \
+  -e PORT=3100 \
+  -e NODE_ENV=prd \
+  -e BASE_URL=/prd \
+  dengelma/nuernbergspots
+```
+
+## 5. CI/CD Pipeline Integration
+
+### GitHub Actions / GitLab CI
+
+**WICHTIG:** Nutzen Sie **Secrets** für API Keys, niemals hardcoded!
+
+#### GitHub Actions Beispiel
+
+Die Deployment-Pipeline ist bereits konfiguriert! Sie müssen nur die Secrets hinzufügen:
+
+1. **Secrets hinzufügen:**
+   - Gehen Sie zu Repository → Settings → Secrets and variables → Actions
+   - Klicken Sie auf "New repository secret"
+   - **Für Dev-Umgebung:**
+     - Name: `MISTRAL_API_KEY_DEV`
+     - Value: Ihr Mistral API Key für Test/Dev
+     - Environment: `dev` (optional, für bessere Isolation)
+   - **Für Produktionsumgebung:**
+     - Name: `MISTRAL_API_KEY_PRD`
+     - Value: Ihr Mistral API Key für Produktion
+     - Environment: `prd` (optional, für bessere Isolation)
+
+2. **Die Workflow-Datei ist bereits aktualisiert:**
+   Die `.github/workflows/deployment.yml` verwendet bereits:
+   ```yaml
+   -e MISTRAL_API_KEY=${{ secrets.MISTRAL_API_KEY_DEV }}  # für dev
+   -e MISTRAL_API_KEY=${{ secrets.MISTRAL_API_KEY_PRD }}   # für prd
+   -e MISTRAL_BASE_URL=https://api.mistral.ai/v1
+   ```
+
+**WICHTIG:** 
+- Verwenden Sie separate API Keys für Dev und Produktion (empfohlen)
+- Oder verwenden Sie den gleichen Key für beide, dann setzen Sie beide Secrets auf den gleichen Wert
+
+#### GitLab CI Beispiel
+
+1. **CI/CD Variables hinzufügen:**
+   - Gehen Sie zu Project → Settings → CI/CD → Variables
+   - Klicken Sie auf "Add variable"
+   - Key: `MISTRAL_API_KEY`
+   - Value: Ihr Mistral API Key
+   - Markieren Sie als "Protected" und "Masked"
+
+2. **In .gitlab-ci.yml verwenden:**
+```yaml
+deploy:
+  script:
+    - docker buildx build --platform linux/amd64 \
+        --build-arg NODE_ENV=prd \
+        -t dengelma/nuernbergspots \
+        --push .
+    - |
+      ssh root@87.106.208.51 << EOF
+        docker stop nuernbergspots || true
+        docker rm nuernbergspots || true
+        docker pull dengelma/nuernbergspots
+        docker run -d --name nuernbergspots -p 3100:3100 --restart unless-stopped \
+          -e PORT=3100 \
+          -e NODE_ENV=prd \
+          -e BASE_URL=/prd \
+          -e MISTRAL_API_KEY=${MISTRAL_API_KEY} \
+          -e MISTRAL_BASE_URL=https://api.mistral.ai/v1 \
+          dengelma/nuernbergspots
+      EOF
+  only:
+    - main
+```
+
+## 6. Docker Compose aktualisieren
+
+Aktualisieren Sie `docker-compose.yml` um Mistral-Variablen zu unterstützen:
+
+```yaml
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    env_file:
+      - ${ENV_FILE:-.env}
+    environment:
+      - NODE_ENV=${NODE_ENV:-development}
+      - PORT=${PORT:-3000}
+      # ... andere Variablen ...
+      # Mistral AI API
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+      - MISTRAL_BASE_URL=${MISTRAL_BASE_URL:-https://api.mistral.ai/v1}
+```
+
+## 7. Sicherheitsbest Practices
+
+### ✅ DO:
+- ✅ Nutzen Sie Secrets Management (GitHub Secrets, GitLab Variables, etc.)
+- ✅ Verwenden Sie separate API Keys für Test und Produktion
+- ✅ Rotieren Sie API Keys regelmäßig
+- ✅ Überwachen Sie API-Nutzung und Kosten
+- ✅ Nutzen Sie `.env` Dateien, die nicht im Repository sind
+- ✅ Setzen Sie Berechtigungen auf `.env` Dateien: `chmod 600 .env`
+
+### ❌ DON'T:
+- ❌ Committen Sie API Keys niemals ins Repository
+- ❌ Hardcoden Sie API Keys im Code
+- ❌ Teilen Sie API Keys in Chat/Email/Slack
+- ❌ Nutzen Sie den gleichen API Key für Test und Produktion
+- ❌ Loggen Sie API Keys (sie werden automatisch maskiert)
+
+## 8. Verifizierung
+
+### API Key testen
+
+```bash
+# Direkter API-Test
+curl https://api.mistral.ai/v1/models \
+  -H "Authorization: Bearer YOUR_MISTRAL_API_KEY"
+
+# Über den Backend-Endpoint
+curl -X POST http://localhost:3000/events/scrape/llm \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN" \
+  -d '{"url": "https://eventfinder.de/nuernberg"}'
+```
+
+### Logs prüfen
+
+```bash
+# Docker Logs
+docker logs nuernbergspots-test
+
+# Suchen Sie nach:
+# - "MISTRAL_API_KEY nicht gesetzt" (Warnung, wenn Key fehlt)
+# - "Mistral-Extraktion erfolgreich" (bei erfolgreicher Extraktion)
+# - API-Fehler (bei ungültigem Key)
+```
+
+## 9. Troubleshooting
+
+### Problem: "MISTRAL_API_KEY nicht gesetzt"
+
+**Lösung:**
+- Prüfen Sie, ob die Environment-Variable gesetzt ist: `echo $MISTRAL_API_KEY`
+- Bei Docker: Prüfen Sie `docker inspect nuernbergspots | grep MISTRAL`
+- Stellen Sie sicher, dass die Variable beim `docker run` übergeben wird
+
+### Problem: "401 Unauthorized"
+
+**Lösung:**
+- API Key ist ungültig oder abgelaufen
+- Generieren Sie einen neuen API Key im Mistral Dashboard
+- Aktualisieren Sie die Environment-Variable
+
+### Problem: "Rate limit exceeded"
+
+**Lösung:**
+- Mistral hat Rate Limits (abhängig vom Plan)
+- Implementieren Sie Retry-Logic mit Exponential Backoff
+- Überwachen Sie die Nutzung über `/events/scrape/llm/costs`
+
+## 10. Kostenüberwachung
+
+### Dashboard
+
+- Mistral Dashboard: [https://console.mistral.ai/](https://console.mistral.ai/)
+- Überwachen Sie Nutzung und Kosten regelmäßig
+
+### API-Endpoint
+
+```bash
+# Kosten abrufen
+curl http://localhost:3000/events/scrape/llm/costs \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN"
+
+# Token-Verbrauch abrufen
+curl http://localhost:3000/events/scrape/llm/tokens \
+  -H "Authorization: Bearer YOUR_FIREBASE_TOKEN"
+```
+
+## Zusammenfassung
+
+1. **Token erhalten:** Mistral Console → API Keys → Create API Key
+2. **Lokal:** `.env` Datei mit `MISTRAL_API_KEY` erstellen
+3. **Docker:** Environment-Variable beim `docker run` übergeben oder `--env-file` nutzen
+4. **CI/CD:** Secrets in GitHub/GitLab konfigurieren und in Workflow verwenden
+5. **Sicherheit:** Niemals API Keys committen oder hardcoden!

--- a/docs/scraping-analysis.md
+++ b/docs/scraping-analysis.md
@@ -191,6 +191,8 @@ Statt hartcodierter CSS-Selektoren nutzen wir LLMs zur semantischen Extraktion v
 
 ```typescript
 // src/events/infrastructure/llm/mistral-extractor.service.ts
+// Hinweis: Wir nutzen das 'openai' npm-Package, weil Mistral eine OpenAI-kompatible API hat
+// Wir verwenden NICHT die OpenAI-API selbst, sondern nur das Package für Mistral
 import OpenAI from 'openai';
 
 @Injectable()
@@ -199,7 +201,8 @@ export class MistralExtractorService {
   private readonly logger = new Logger(MistralExtractorService.name);
 
   constructor() {
-    // Mistral AI API (oder DeepInfra als Alternative)
+    // Mistral AI API nutzt OpenAI-kompatibles Format
+    // baseURL zeigt auf Mistral, nicht auf OpenAI
     this.client = new OpenAI({
       baseURL: process.env.MISTRAL_BASE_URL || 'https://api.mistral.ai/v1',
       apiKey: process.env.MISTRAL_API_KEY,
@@ -240,12 +243,15 @@ export class MistralExtractorService {
 
 ```typescript
 // Via DeepInfra (kann günstiger sein)
+// Auch hier: openai-Package, aber baseURL zeigt auf DeepInfra
 this.client = new OpenAI({
   baseURL: 'https://api.deepinfra.com/v1/openai',
   apiKey: process.env.DEEPINFRA_API_KEY,
 });
 // Modell: 'mistralai/Mistral-Small-2409'
 ```
+
+**Wichtig:** Das `openai` npm-Package wird nur verwendet, weil Mistral und DeepInfra OpenAI-kompatible APIs haben. Wir nutzen **nicht** die OpenAI-API selbst, sondern nur das Package als Client-Bibliothek für Mistral/DeepInfra.
 
 **JSON Schema für Events:**
 
@@ -522,11 +528,21 @@ const MODEL_PRICING = {
 
 ### Phase 1: LLM-Infrastruktur (1 Woche)
 
-- [ ] `openai` Package installieren (für Mistral API)
+**Benötigte npm-Packages:**
+- `openai` - Für Mistral API (OpenAI-kompatible API, **nicht** die OpenAI-API selbst)
+- `@google/generative-ai` - Optional, nur wenn Gemini als Fallback verwendet wird
+
+**Aufgaben:**
+- [ ] `openai` npm-Package installieren (als Client für Mistral API)
 - [ ] `MistralExtractorService` implementieren
 - [ ] HTML-Cleaner entwickeln
 - [ ] JSON-Schema für Events definieren
 - [ ] Unit-Tests schreiben
+
+**Wichtig:** 
+- Das `openai` Package wird benötigt, weil Mistral eine OpenAI-kompatible API hat
+- Wir verwenden **nicht** die OpenAI-API selbst, sondern nur das Package als Client-Bibliothek für Mistral
+- Für Gemini (optionaler Fallback) wird ein separates Package (`@google/generative-ai`) benötigt
 
 ### Phase 2: Integration & Fallback (1 Woche)
 

--- a/docs/scraping-analysis.md
+++ b/docs/scraping-analysis.md
@@ -22,12 +22,12 @@
 
 Die aktuelle Scraping-Implementierung basiert auf **Puppeteer** mit hartcodierten CSS-Selektoren für 5 Event-Quellen. Dieser Ansatz ist **fragil und wartungsintensiv**, da HTML-Strukturänderungen der Zielseiten sofortige Code-Anpassungen erfordern.
 
-**Empfehlung:** LLM-basierte Extraktion mit gestaffeltem Modell-Ansatz:
+**Empfehlung:** LLM-basierte Extraktion mit Mistral Small 3.2 (europäisches Modell):
 
-1. **Primär:** LLM-basierte Extraktion (Gemini Flash 2.0 / DeepSeek-V3 / lokales Modell)
+1. **Primär:** Mistral Small 3.2 (europäisches Modell, sehr günstig)
 2. **Fallback:** Bestehende Puppeteer-Scraper als Backup
 
-**Geschätzte Kosten:** €0-10/Monat (je nach Modellwahl)
+**Geschätzte Kosten:** ~€0.75/Monat (bei 50 Seiten/Woche)
 
 ---
 
@@ -152,82 +152,99 @@ Statt hartcodierter CSS-Selektoren nutzen wir LLMs zur semantischen Extraktion v
 
 ### LLM-Modell-Vergleich
 
-| Modell | Input-Preis | Output-Preis | Structured Output | Empfehlung |
-|--------|-------------|--------------|-------------------|------------|
-| **Gemini Flash 2.0** | $0.10/1M | $0.40/1M | ✅ Ja | ⭐ **Beste Wahl** |
-| **DeepSeek-V3** | $0.07-0.27/1M | $1.10/1M | ✅ Ja | ⭐ Sehr günstig |
-| **Mistral Small 3.2** | $0.075/1M | $0.20/1M | ✅ JSON Mode | ⭐ Günstig |
-| **GPT-4o-mini** | $0.15/1M | $0.60/1M | ❌ Nein | ⚠️ Kein Structured Output |
-| **GPT-4o** | $2.50/1M | $10/1M | ✅ Ja | 💰 Teuer |
-| **Ollama (lokal)** | Kostenlos | Kostenlos | ✅ Ja | 🖥️ Eigene Hardware |
-| **Claude Haiku** | $1.00/1M | $5.00/1M | ✅ Ja | 💰 Mittlere Kosten |
+| Modell | Input-Preis | Output-Preis | Structured Output | Herkunft | Empfehlung |
+|--------|-------------|--------------|-------------------|----------|------------|
+| **Mistral Small 3.2** | $0.075/1M | $0.20/1M | ✅ JSON Mode | 🇪🇺 Europa | ⭐ **Empfohlen** |
+| **Gemini Flash 2.0** | $0.10/1M | $0.40/1M | ✅ Ja | 🇺🇸 USA | ⭐ Alternative |
+| **DeepSeek-V3** | $0.27/1M | $1.10/1M | ✅ Ja | 🇨🇳 China | ⚠️ Teurer |
+| **GPT-4o-mini** | $0.15/1M | $0.60/1M | ❌ Nein | 🇺🇸 USA | ⚠️ Kein Structured Output |
+| **GPT-4o** | $2.50/1M | $10/1M | ✅ Ja | 🇺🇸 USA | 💰 Zu teuer |
+| **Claude Haiku** | $1.00/1M | $5.00/1M | ✅ Ja | 🇺🇸 USA | 💰 Teuer |
 
-#### Kostenberechnung (100 Seiten/Tag, ~30 Tage)
+#### Kostenberechnung (50 Seiten/Woche = ~200 Seiten/Monat)
 
-Annahmen: ~50.000 Input-Tokens pro Seite (bereinigtes HTML), ~2.000 Output-Tokens
+**Annahmen:** 
+- ~50.000 Input-Tokens pro Seite (bereinigtes HTML)
+- ~2.000 Output-Tokens pro Seite
+- **Monatlich:** 200 Seiten × 50.000 = 10M Input-Tokens, 200 × 2.000 = 0.4M Output-Tokens
 
-| Modell | Input-Kosten/Monat | Output-Kosten/Monat | **Gesamt/Monat** |
-|--------|-------------------|---------------------|------------------|
-| **Gemini Flash 2.0** | $15.00 | $2.40 | **~$17** |
-| **DeepSeek-V3** | $4.05-13.50 | $6.60 | **~$11-20** |
-| **Mistral Small 3.2** | $11.25 | $1.20 | **~$12** |
-| **Ollama (lokal)** | $0 | $0 | **$0** |
-| **GPT-4o** | $375 | $60 | **$435** ❌ |
+| Modell | Input-Kosten/Monat | Output-Kosten/Monat | **Gesamt/Monat** | **Gesamt/Jahr** |
+|--------|-------------------|---------------------|------------------|-----------------|
+| **Mistral Small 3.2** | $0.75 | $0.08 | **~$0.83** | **~$10** |
+| **Gemini Flash 2.0** | $1.00 | $0.16 | **~$1.16** | **~$14** |
+| **DeepSeek-V3** | $2.70 | $0.44 | **~$3.14** | **~$38** |
+| **GPT-4o** | $25.00 | $4.00 | **~$29** ❌ | **~$348** ❌ |
 
 ---
 
-### Ansatz 1: Cloud-LLM mit Gemini Flash 2.0 (Empfohlen)
+### Ansatz 1: Mistral Small 3.2 (Empfohlen - Europäisches Modell)
 
-**Warum Gemini Flash 2.0?**
-- ✅ **Kostenloser Tier verfügbar** (1.500 Requests/Tag, 1M Tokens/Minute)
-- ✅ Natives Structured Output (JSON Schema)
-- ✅ 1M Token Context Window
-- ✅ Sehr schnelle Inferenz
+**Warum Mistral Small 3.2?**
+- ✅ **Europäisches Modell** (DSGVO-konform, Datenschutz)
+- ✅ **Sehr günstig** (~$0.83/Monat bei 50 Seiten/Woche)
+- ✅ JSON Mode für strukturierte Ausgaben
+- ✅ OpenAI-kompatible API (einfache Integration)
+- ✅ Gute Qualität für strukturierte Extraktion
+- ✅ Verfügbar via DeepInfra oder direkt von Mistral AI
 
 **Implementierung:**
 
 ```typescript
-// src/events/infrastructure/llm/gemini-extractor.service.ts
-import { GoogleGenerativeAI } from '@google/generative-ai';
+// src/events/infrastructure/llm/mistral-extractor.service.ts
+import OpenAI from 'openai';
 
 @Injectable()
-export class GeminiExtractorService {
-  private readonly genAI: GoogleGenerativeAI;
-  private readonly model;
+export class MistralExtractorService {
+  private readonly client: OpenAI;
+  private readonly logger = new Logger(MistralExtractorService.name);
 
   constructor() {
-    this.genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    this.model = this.genAI.getGenerativeModel({
-      model: 'gemini-2.0-flash',
-      generationConfig: {
-        responseMimeType: 'application/json',
-        responseSchema: EVENT_ARRAY_SCHEMA,
-      },
+    // Mistral AI API (oder DeepInfra als Alternative)
+    this.client = new OpenAI({
+      baseURL: process.env.MISTRAL_BASE_URL || 'https://api.mistral.ai/v1',
+      apiKey: process.env.MISTRAL_API_KEY,
     });
   }
 
   async extractEvents(html: string): Promise<ExtractedEvent[]> {
-    const cleanedHtml = this.cleanHtml(html);
+    const cleanedHtml = HtmlCleaner.extractMainContent(html);
     
-    const result = await this.model.generateContent([
-      EVENT_EXTRACTION_PROMPT,
-      cleanedHtml,
-    ]);
+    const response = await this.client.chat.completions.create({
+      model: 'mistral-small-latest', // oder 'mistral-small-2409'
+      messages: [
+        {
+          role: 'system',
+          content: EVENT_EXTRACTION_SYSTEM_PROMPT,
+        },
+        {
+          role: 'user',
+          content: `Extrahiere alle Events aus folgendem HTML:\n\n${cleanedHtml}`,
+        },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0, // Deterministisch für strukturierte Daten
+    });
 
-    return JSON.parse(result.response.text());
-  }
+    const content = response.choices[0].message.content;
+    if (!content) {
+      throw new Error('Keine Antwort von Mistral API erhalten');
+    }
 
-  private cleanHtml(html: string): string {
-    // Entferne Scripts, Styles, Kommentare
-    return html
-      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-      .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
-      .replace(/<!--[\s\S]*?-->/g, '')
-      .replace(/<(header|footer|nav|aside)[^>]*>[\s\S]*?<\/\1>/gi, '')
-      .replace(/\s+/g, ' ')
-      .trim();
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed.events) ? parsed.events : parsed;
   }
 }
+```
+
+**Alternative: DeepInfra (oft günstiger):**
+
+```typescript
+// Via DeepInfra (kann günstiger sein)
+this.client = new OpenAI({
+  baseURL: 'https://api.deepinfra.com/v1/openai',
+  apiKey: process.env.DEEPINFRA_API_KEY,
+});
+// Modell: 'mistralai/Mistral-Small-2409'
 ```
 
 **JSON Schema für Events:**
@@ -263,143 +280,52 @@ const EVENT_ARRAY_SCHEMA = {
 
 ---
 
-### Ansatz 2: DeepSeek-V3 (Günstigste Cloud-Option)
+### Ansatz 2: Gemini Flash 2.0 (Alternative mit Free Tier)
 
 **Vorteile:**
-- ✅ Extrem günstig ($0.07-0.27/1M Input)
-- ✅ Gute Qualität für strukturierte Extraktion
-- ✅ OpenAI-kompatible API
+- ✅ **Kostenloser Tier verfügbar** (1.500 Requests/Tag, 1M Tokens/Minute)
+- ✅ Natives Structured Output (JSON Schema)
+- ✅ 1M Token Context Window
+- ✅ Sehr schnelle Inferenz
 
 **Implementierung:**
 
 ```typescript
-// src/events/infrastructure/llm/deepseek-extractor.service.ts
-import OpenAI from 'openai';
+// src/events/infrastructure/llm/gemini-extractor.service.ts
+import { GoogleGenerativeAI } from '@google/generative-ai';
 
 @Injectable()
-export class DeepSeekExtractorService {
-  private readonly client: OpenAI;
+export class GeminiExtractorService {
+  private readonly genAI: GoogleGenerativeAI;
+  private readonly model;
 
   constructor() {
-    this.client = new OpenAI({
-      baseURL: 'https://api.deepseek.com',
-      apiKey: process.env.DEEPSEEK_API_KEY,
-    });
-  }
-
-  async extractEvents(html: string): Promise<ExtractedEvent[]> {
-    const response = await this.client.chat.completions.create({
-      model: 'deepseek-chat',
-      messages: [
-        {
-          role: 'system',
-          content: EVENT_EXTRACTION_SYSTEM_PROMPT,
-        },
-        {
-          role: 'user',
-          content: `Extrahiere alle Events aus folgendem HTML:\n\n${this.cleanHtml(html)}`,
-        },
-      ],
-      response_format: { type: 'json_object' },
-      temperature: 0,
-    });
-
-    const content = response.choices[0].message.content;
-    return JSON.parse(content).events;
-  }
-}
-```
-
----
-
-### Ansatz 3: Lokales LLM mit Ollama (Kostenlos)
-
-**Vorteile:**
-- ✅ **Komplett kostenlos** (keine API-Kosten)
-- ✅ Datenschutz (Daten verlassen Server nicht)
-- ✅ Keine Rate-Limits
-- ✅ Structured Output seit Dezember 2024
-
-**Nachteile:**
-- ❌ Erfordert GPU-Server (8-16GB VRAM empfohlen)
-- ❌ Langsamere Inferenz als Cloud
-- ❌ Selbst-Hosting erforderlich
-
-**Empfohlene lokale Modelle:**
-
-| Modell | VRAM | Qualität | Geschwindigkeit |
-|--------|------|----------|-----------------|
-| **Llama 3.2 3B** | 4GB | ⭐⭐ | Schnell |
-| **Mistral 7B** | 8GB | ⭐⭐⭐ | Mittel |
-| **Llama 3.1 8B** | 8GB | ⭐⭐⭐⭐ | Mittel |
-| **Mixtral 8x7B** | 24GB | ⭐⭐⭐⭐⭐ | Langsam |
-
-**Implementierung:**
-
-```typescript
-// src/events/infrastructure/llm/ollama-extractor.service.ts
-import { Ollama } from 'ollama';
-
-@Injectable()
-export class OllamaExtractorService {
-  private readonly ollama: Ollama;
-
-  constructor() {
-    this.ollama = new Ollama({
-      host: process.env.OLLAMA_HOST || 'http://localhost:11434',
-    });
-  }
-
-  async extractEvents(html: string): Promise<ExtractedEvent[]> {
-    const response = await this.ollama.chat({
-      model: 'llama3.1:8b',
-      messages: [
-        {
-          role: 'system',
-          content: EVENT_EXTRACTION_SYSTEM_PROMPT,
-        },
-        {
-          role: 'user',
-          content: `Extrahiere alle Events:\n\n${this.cleanHtml(html)}`,
-        },
-      ],
-      format: EVENT_ARRAY_SCHEMA,
-      options: {
-        temperature: 0,
+    this.genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+    this.model = this.genAI.getGenerativeModel({
+      model: 'gemini-2.0-flash',
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseSchema: EVENT_ARRAY_SCHEMA,
       },
     });
+  }
 
-    return JSON.parse(response.message.content);
+  async extractEvents(html: string): Promise<ExtractedEvent[]> {
+    const cleanedHtml = HtmlCleaner.extractMainContent(html);
+    
+    const result = await this.model.generateContent([
+      EVENT_EXTRACTION_PROMPT,
+      cleanedHtml,
+    ]);
+
+    return JSON.parse(result.response.text());
   }
 }
 ```
 
-**Docker-Setup für Ollama:**
-
-```yaml
-# docker-compose.ollama.yml
-services:
-  ollama:
-    image: ollama/ollama:latest
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
-
-volumes:
-  ollama_data:
-```
-
 ---
 
-### Ansatz 4: Hybrid-Strategie (Empfohlen für Produktion)
+### Ansatz 3: Hybrid-Strategie (Empfohlen für Produktion)
 
 Kombiniere mehrere Ansätze für optimale Kosten und Zuverlässigkeit:
 
@@ -408,16 +334,17 @@ Kombiniere mehrere Ansätze für optimale Kosten und Zuverlässigkeit:
 @Injectable()
 export class HybridExtractorService {
   private readonly extractors: LlmExtractor[];
+  private readonly logger = new Logger(HybridExtractorService.name);
 
   constructor(
+    private readonly mistralExtractor: MistralExtractorService,
     private readonly geminiExtractor: GeminiExtractorService,
-    private readonly ollamaExtractor: OllamaExtractorService,
     private readonly puppeteerFallback: ScraperService,
   ) {
-    // Priorisierte Reihenfolge
+    // Priorisierte Reihenfolge: Mistral (europäisch, günstig) → Gemini (Free Tier) → Puppeteer
     this.extractors = [
+      { name: 'mistral', service: mistralExtractor },
       { name: 'gemini', service: geminiExtractor },
-      { name: 'ollama', service: ollamaExtractor },
     ];
   }
 
@@ -428,7 +355,7 @@ export class HybridExtractorService {
     for (const extractor of this.extractors) {
       try {
         const events = await extractor.service.extractEvents(html);
-        if (events.length > 0) {
+        if (events && events.length > 0) {
           this.logger.log(`${extractor.name} erfolgreich: ${events.length} Events`);
           return events;
         }
@@ -439,7 +366,18 @@ export class HybridExtractorService {
 
     // Fallback zu klassischem Scraper
     this.logger.log('Fallback zu Puppeteer-Scraper');
-    return this.puppeteerFallback.scrapeEventsFromUrl(url);
+    const result = await this.puppeteerFallback.scrapeEventsFromUrl(url);
+    return result.events;
+  }
+
+  private async fetchHtml(url: string): Promise<string> {
+    // Nutze Puppeteer für JS-gerenderte Seiten
+    const puppeteerManager = PuppeteerManager.getInstance();
+    const page = await puppeteerManager.getPage();
+    await page.goto(url, { waitUntil: 'networkidle0' });
+    const html = await page.content();
+    await page.close();
+    return html;
   }
 }
 ```
@@ -448,9 +386,9 @@ export class HybridExtractorService {
 
 | Szenario | Primär | Fallback 1 | Fallback 2 |
 |----------|--------|------------|------------|
-| **Kostenoptimiert** | Ollama (lokal) | Gemini Free Tier | Puppeteer |
-| **Qualitätsoptimiert** | Gemini Flash | DeepSeek | Puppeteer |
-| **Maximal günstig** | Ollama (lokal) | Puppeteer | - |
+| **Empfohlen** | Mistral Small 3.2 | Gemini Flash (Free Tier) | Puppeteer |
+| **Kostenoptimiert** | Mistral Small 3.2 | Puppeteer | - |
+| **Qualitätsoptimiert** | Mistral Small 3.2 | Gemini Flash | Puppeteer |
 
 ---
 
@@ -572,10 +510,9 @@ export class CostTrackerService {
 }
 
 const MODEL_PRICING = {
+  'mistral-small-latest': { input: 0.075, output: 0.20 },
   'gemini-2.0-flash': { input: 0.10, output: 0.40 },
   'deepseek-chat': { input: 0.27, output: 1.10 },
-  'mistral-small': { input: 0.075, output: 0.20 },
-  'ollama': { input: 0, output: 0 },
 };
 ```
 
@@ -585,8 +522,8 @@ const MODEL_PRICING = {
 
 ### Phase 1: LLM-Infrastruktur (1 Woche)
 
-- [ ] `@google/generative-ai` Package installieren
-- [ ] `GeminiExtractorService` implementieren
+- [ ] `openai` Package installieren (für Mistral API)
+- [ ] `MistralExtractorService` implementieren
 - [ ] HTML-Cleaner entwickeln
 - [ ] JSON-Schema für Events definieren
 - [ ] Unit-Tests schreiben
@@ -594,7 +531,8 @@ const MODEL_PRICING = {
 ### Phase 2: Integration & Fallback (1 Woche)
 
 - [ ] `HybridExtractorService` implementieren
-- [ ] Fallback zu bestehenden Scrapern einbauen
+- [ ] Gemini als Fallback integrieren (optional)
+- [ ] Fallback zu bestehenden Puppeteer-Scrapern einbauen
 - [ ] Error-Handling und Retry-Logik
 - [ ] Kosten-Tracking
 
@@ -609,8 +547,8 @@ const MODEL_PRICING = {
 
 - [ ] Caching für wiederkehrende URLs
 - [ ] Prompt-Optimierung basierend auf Ergebnissen
-- [ ] Ollama-Setup als kostenfreie Alternative
 - [ ] Monitoring-Dashboard
+- [ ] Kosten-Analyse und Optimierung
 
 ---
 
@@ -655,12 +593,17 @@ const MODEL_PRICING = {
 
 ## 📝 Fazit
 
-Der **LLM-basierte Ansatz mit Gemini Flash 2.0** (oder Ollama für Kosten=0) bietet:
+Der **LLM-basierte Ansatz mit Mistral Small 3.2** bietet:
 
 1. **Robustheit** gegen HTML-Strukturänderungen
 2. **Einheitliche Implementierung** für alle Quellen
-3. **Geringe Kosten** (~€10-15/Monat oder kostenlos mit Ollama)
-4. **Zukunftssicher** durch semantisches Verständnis
+3. **Sehr geringe Kosten** (~€0.75/Monat bei 50 Seiten/Woche)
+4. **Europäisches Modell** (DSGVO-konform, Datenschutz)
+5. **Zukunftssicher** durch semantisches Verständnis
+
+**Kostenübersicht bei realistischer Nutzung (50 Seiten/Woche):**
+- Mistral Small 3.2: **~€0.75/Monat** (~€10/Jahr)
+- Gemini Flash 2.0: **~€1.16/Monat** (~€14/Jahr) - mit Free Tier möglicherweise kostenlos
 
 Der bestehende Puppeteer-Ansatz bleibt als **Fallback** erhalten und wird nur aktiviert, wenn die LLM-Extraktion fehlschlägt.
 
@@ -668,8 +611,9 @@ Der bestehende Puppeteer-Ansatz bleibt als **Fallback** erhalten und wird nur ak
 
 ## 🔗 Referenzen
 
+- [Mistral AI API Dokumentation](https://docs.mistral.ai/)
+- [Mistral JSON Mode](https://docs.mistral.ai/capabilities/structured_output/json_mode)
+- [Mistral Pricing](https://mistral.ai/pricing/)
+- [DeepInfra Mistral](https://deepinfra.com/mistralai/Mistral-Small-2409) (Alternative Hosting)
 - [Gemini API Dokumentation](https://ai.google.dev/gemini-api/docs)
 - [Gemini Structured Output](https://ai.google.dev/gemini-api/docs/structured-output)
-- [DeepSeek API](https://api-docs.deepseek.com/)
-- [Ollama Structured Outputs](https://ollama.com/blog/structured-outputs)
-- [Mistral JSON Mode](https://docs.mistral.ai/capabilities/structured_output/json_mode)

--- a/docs/scraping-analysis.md
+++ b/docs/scraping-analysis.md
@@ -1,6 +1,7 @@
 # Event-Scraping Analyse & Empfehlungen
 
 **Erstellt:** 09. Januar 2026  
+**Aktualisiert:** 09. Januar 2026  
 **Branch:** `feature/scraping-analysis-improvement`  
 **Status:** Analyse-Phase
 
@@ -11,9 +12,9 @@
 1. [Executive Summary](#executive-summary)
 2. [Aktuelle Implementierung](#aktuelle-implementierung)
 3. [Identifizierte Probleme](#identifizierte-probleme)
-4. [Alternative Ansätze](#alternative-ansätze)
-5. [Empfehlung](#empfehlung)
-6. [Implementierungsplan](#implementierungsplan)
+4. [LLM-basierte Lösung (Empfohlen)](#llm-basierte-lösung-empfohlen)
+5. [Implementierungsplan](#implementierungsplan)
+6. [Abgelehnte Alternativen](#abgelehnte-alternativen)
 
 ---
 
@@ -21,12 +22,12 @@
 
 Die aktuelle Scraping-Implementierung basiert auf **Puppeteer** mit hartcodierten CSS-Selektoren für 5 Event-Quellen. Dieser Ansatz ist **fragil und wartungsintensiv**, da HTML-Strukturänderungen der Zielseiten sofortige Code-Anpassungen erfordern.
 
-**Empfehlung:** Hybrid-Ansatz mit:
-1. **Primär:** LLM-basierte Extraktion (OpenAI GPT-4o mit Structured Outputs)
-2. **Sekundär:** Offizielle APIs wo verfügbar (Eventbrite API, Eventfrog API)
-3. **Fallback:** Optimierte Puppeteer-Scraper als Backup
+**Empfehlung:** LLM-basierte Extraktion mit gestaffeltem Modell-Ansatz:
 
-**Geschätzte Kosten:** ~€10-30/Monat bei moderater Nutzung
+1. **Primär:** LLM-basierte Extraktion (Gemini Flash 2.0 / DeepSeek-V3 / lokales Modell)
+2. **Fallback:** Bestehende Puppeteer-Scraper als Backup
+
+**Geschätzte Kosten:** €0-10/Monat (je nach Modellwahl)
 
 ---
 
@@ -114,300 +115,561 @@ const locationText = element.querySelector('.card-body-footer')?.textContent?.tr
 
 ---
 
-## 🔄 Alternative Ansätze
+## 🤖 LLM-basierte Lösung (Empfohlen)
 
-### Option A: LLM-basierte Extraktion (Empfohlen)
+### Konzept-Übersicht
 
-**Technologie:** OpenAI GPT-4o mit Structured Outputs
-
-**Konzept:**
-```typescript
-// Beispiel: LLM-basierte Event-Extraktion
-const response = await openai.chat.completions.create({
-  model: "gpt-4o",
-  response_format: {
-    type: "json_schema",
-    json_schema: {
-      name: "event_extraction",
-      schema: eventSchema
-    }
-  },
-  messages: [{
-    role: "user",
-    content: `Extrahiere alle Events aus folgendem HTML. 
-              Gib nur valides JSON zurück.\n\n${pageContent}`
-  }]
-});
-```
-
-**Vorteile:**
-- ✅ Robust gegen HTML-Strukturänderungen
-- ✅ Versteht Kontext und semantische Bedeutung
-- ✅ Einheitliche Implementierung für alle Quellen
-- ✅ Automatische Normalisierung der Daten
-- ✅ 100% valide JSON-Outputs garantiert
-
-**Nachteile:**
-- ❌ API-Kosten (~$0.01-0.03 pro Seite)
-- ❌ Latenz (~2-5s pro Anfrage)
-- ❌ Token-Limits bei großen Seiten
-
-**Geschätzte Kosten:**
-- GPT-4o: ~$2.50/1M input tokens, ~$10/1M output tokens
-- Bei 100 Seiten/Tag: ~$5-15/Monat
-
-### Option B: Event-APIs nutzen
-
-**Verfügbare APIs:**
-
-| API | Kostenlos | Umfang | Relevanz |
-|-----|-----------|--------|----------|
-| **Eventbrite API** | Ja (Rate Limits) | Weltweit | ⭐⭐⭐ Hoch |
-| **Eventfrog API** | Ja | CH/DE | ⭐⭐ Mittel |
-| **AllEvents API** | Freemium | 200M+ Events | ⭐⭐ Mittel |
-| **PredictHQ** | Freemium | Aggregator | ⭐ Niedrig |
-
-**Eventbrite API Beispiel:**
-```typescript
-// GET /events/search/
-const response = await fetch(
-  'https://www.eventbriteapi.com/v3/events/search/?location.address=Nürnberg',
-  { headers: { 'Authorization': `Bearer ${EVENTBRITE_TOKEN}` }}
-);
-```
-
-**Vorteile:**
-- ✅ Strukturierte, zuverlässige Daten
-- ✅ Keine Wartung bei Webseiten-Änderungen
-- ✅ Offizielle Bilder, Beschreibungen, Geodaten
-- ✅ Pagination und Filtering eingebaut
-
-**Nachteile:**
-- ❌ Begrenzte Quellen (nur API-Partner)
-- ❌ Rate Limits
-- ❌ Nicht alle lokalen Events verfügbar
-
-### Option C: Scraping-as-a-Service
-
-**Anbieter:**
-
-| Service | Free Tier | Preis | Features |
-|---------|-----------|-------|----------|
-| **Firecrawl** | 500 Credits | $16/Mo | AI-Extraktion, LLM-ready |
-| **Browserless** | 6h/Mo | $99/Mo | Puppeteer-Hosting |
-| **ScrapingBee** | 1000 Credits | $49/Mo | Residential Proxies |
-| **Crawl4AI** | Open Source | Kostenlos | Self-hosted |
-
-**Firecrawl Beispiel:**
-```typescript
-import Firecrawl from '@mendable/firecrawl-js';
-
-const app = new Firecrawl({ apiKey: 'fc-xxx' });
-const result = await app.scrapeUrl('https://eventfinder.de/nuernberg', {
-  formats: ['extract'],
-  extract: {
-    schema: eventSchema,
-    systemPrompt: 'Extrahiere Event-Daten in deutscher Sprache'
-  }
-});
-```
-
-**Vorteile:**
-- ✅ Managed Infrastructure
-- ✅ AI-basierte Extraktion integriert
-- ✅ Proxy-Rotation, CAPTCHA-Handling
-
-**Nachteile:**
-- ❌ Laufende Kosten
-- ❌ Abhängigkeit von Drittanbieter
-
-### Option D: Optimierter aktueller Ansatz
-
-**Verbesserungen am bestehenden System:**
-
-1. **Resiliente Selektoren:**
-```typescript
-// Fallback-Ketten für mehr Robustheit
-const title = element.querySelector('.titel, .title, h2, h3, [class*="title"]')?.textContent;
-```
-
-2. **Zentrale Konfiguration:**
-```typescript
-// Selektoren in Config-Dateien auslagern
-const scraperConfig = {
-  eventfinder: {
-    selectors: {
-      container: '.card.event',
-      title: '.titel',
-      // ...
-    }
-  }
-};
-```
-
-3. **Health-Checks & Alerts:**
-```typescript
-// Automatische Erkennung von Strukturänderungen
-if (events.length === 0 && page.content().includes('event')) {
-  this.notifyStructureChange('eventfinder');
-}
-```
-
----
-
-## ✅ Empfehlung: Hybrid-Ansatz
-
-### Strategie
+Statt hartcodierter CSS-Selektoren nutzen wir LLMs zur semantischen Extraktion von Event-Daten aus HTML. Das LLM versteht den Kontext und kann Events unabhängig von der HTML-Struktur identifizieren.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Admin-Oberfläche (Frontend)                  │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
-│  │ URL eingeben │→ │ Quelle wählen│→ │ Events prüfen/import │  │
+│  │ URL eingeben │→ │ Events laden │→ │ Events prüfen/import │  │
 │  └──────────────┘  └──────────────┘  └──────────────────────┘  │
 └─────────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────────┐
-│                    Backend Scraping Service                      │
+│                    Backend LLM-Scraper Service                   │
 │                                                                   │
-│  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
-│  │ 1. API      │ → │ 2. LLM      │ → │ 3. Fallback         │  │
-│  │ (Eventbrite)│    │ (GPT-4o)   │    │ (Puppeteer)         │  │
-│  └─────────────┘    └─────────────┘    └─────────────────────┘  │
-│         ↓                  ↓                    ↓                │
 │  ┌─────────────────────────────────────────────────────────────┐│
-│  │              Unified Event Normalizer                        ││
+│  │  1. HTML abrufen (Puppeteer für JS-gerenderte Seiten)       ││
+│  │  2. HTML bereinigen (Scripts/Styles entfernen)               ││
+│  │  3. LLM-Extraktion mit strukturiertem Output                 ││
+│  │  4. Fallback zu klassischem Scraper bei Fehler               ││
+│  └─────────────────────────────────────────────────────────────┘│
+│         ↓                                                        │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │              Event Normalizer                                ││
 │  │  - Deduplizierung                                            ││
-│  │  - Geocoding (Google Maps API)                               ││
+│  │  - Geocoding (optional)                                      ││
 │  │  - Kategorie-Mapping                                         ││
 │  └─────────────────────────────────────────────────────────────┘│
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Priorisierung der Quellen
+---
 
-1. **Eventbrite API** (Kostenlos, strukturiert, ~40% der Events)
-2. **LLM-Extraktion** (Flexibel, ~50% der Events)
-3. **Puppeteer Fallback** (Spezialfälle, ~10% der Events)
+### LLM-Modell-Vergleich
 
-### Kostenanalyse (Monatlich)
+| Modell | Input-Preis | Output-Preis | Structured Output | Empfehlung |
+|--------|-------------|--------------|-------------------|------------|
+| **Gemini Flash 2.0** | $0.10/1M | $0.40/1M | ✅ Ja | ⭐ **Beste Wahl** |
+| **DeepSeek-V3** | $0.07-0.27/1M | $1.10/1M | ✅ Ja | ⭐ Sehr günstig |
+| **Mistral Small 3.2** | $0.075/1M | $0.20/1M | ✅ JSON Mode | ⭐ Günstig |
+| **GPT-4o-mini** | $0.15/1M | $0.60/1M | ❌ Nein | ⚠️ Kein Structured Output |
+| **GPT-4o** | $2.50/1M | $10/1M | ✅ Ja | 💰 Teuer |
+| **Ollama (lokal)** | Kostenlos | Kostenlos | ✅ Ja | 🖥️ Eigene Hardware |
+| **Claude Haiku** | $1.00/1M | $5.00/1M | ✅ Ja | 💰 Mittlere Kosten |
 
-| Komponente | Nutzung | Kosten |
-|------------|---------|--------|
-| OpenAI GPT-4o | ~200 Seiten | ~$10-15 |
-| Eventbrite API | Kostenlos | $0 |
-| Puppeteer (Serverless) | ~50 Seiten | ~$2-5 |
-| Google Geocoding | ~500 Adressen | ~$2-5 |
-| **Gesamt** | | **~$15-25/Monat** |
+#### Kostenberechnung (100 Seiten/Tag, ~30 Tage)
 
-### Technische Implementierung
+Annahmen: ~50.000 Input-Tokens pro Seite (bereinigtes HTML), ~2.000 Output-Tokens
 
-**Neuer LLM-basierter Scraper:**
+| Modell | Input-Kosten/Monat | Output-Kosten/Monat | **Gesamt/Monat** |
+|--------|-------------------|---------------------|------------------|
+| **Gemini Flash 2.0** | $15.00 | $2.40 | **~$17** |
+| **DeepSeek-V3** | $4.05-13.50 | $6.60 | **~$11-20** |
+| **Mistral Small 3.2** | $11.25 | $1.20 | **~$12** |
+| **Ollama (lokal)** | $0 | $0 | **$0** |
+| **GPT-4o** | $375 | $60 | **$435** ❌ |
+
+---
+
+### Ansatz 1: Cloud-LLM mit Gemini Flash 2.0 (Empfohlen)
+
+**Warum Gemini Flash 2.0?**
+- ✅ **Kostenloser Tier verfügbar** (1.500 Requests/Tag, 1M Tokens/Minute)
+- ✅ Natives Structured Output (JSON Schema)
+- ✅ 1M Token Context Window
+- ✅ Sehr schnelle Inferenz
+
+**Implementierung:**
 
 ```typescript
-// src/events/infrastructure/scraping/llm-scraper.service.ts
-@Injectable()
-export class LlmScraperService {
-  constructor(
-    private readonly openaiService: OpenAiService,
-    private readonly puppeteerManager: PuppeteerManager,
-  ) {}
+// src/events/infrastructure/llm/gemini-extractor.service.ts
+import { GoogleGenerativeAI } from '@google/generative-ai';
 
-  async extractEventsFromUrl(url: string): Promise<Event[]> {
-    // 1. HTML abrufen (mit Puppeteer für JS-rendered Seiten)
-    const html = await this.fetchPageContent(url);
-    
-    // 2. HTML bereinigen (Script/Style Tags entfernen)
+@Injectable()
+export class GeminiExtractorService {
+  private readonly genAI: GoogleGenerativeAI;
+  private readonly model;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+    this.model = this.genAI.getGenerativeModel({
+      model: 'gemini-2.0-flash',
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseSchema: EVENT_ARRAY_SCHEMA,
+      },
+    });
+  }
+
+  async extractEvents(html: string): Promise<ExtractedEvent[]> {
     const cleanedHtml = this.cleanHtml(html);
     
-    // 3. LLM-Extraktion mit strukturiertem Output
-    const events = await this.openaiService.extractStructured<Event[]>({
-      model: 'gpt-4o',
-      systemPrompt: EVENT_EXTRACTION_PROMPT,
-      content: cleanedHtml,
-      schema: eventArraySchema,
-    });
-    
-    // 4. Nachbearbeitung (Geocoding, Kategorie-Mapping)
-    return this.normalizeEvents(events);
+    const result = await this.model.generateContent([
+      EVENT_EXTRACTION_PROMPT,
+      cleanedHtml,
+    ]);
+
+    return JSON.parse(result.response.text());
+  }
+
+  private cleanHtml(html: string): string {
+    // Entferne Scripts, Styles, Kommentare
+    return html
+      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+      .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/<(header|footer|nav|aside)[^>]*>[\s\S]*?<\/\1>/gi, '')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
 }
 ```
 
-**Event-Extraktions-Prompt:**
+**JSON Schema für Events:**
 
 ```typescript
-const EVENT_EXTRACTION_PROMPT = `
-Du bist ein Experte für die Extraktion von Event-Daten aus HTML.
+const EVENT_ARRAY_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      title: { type: 'string', description: 'Titel des Events' },
+      description: { type: 'string', description: 'Beschreibung' },
+      date: { type: 'string', description: 'Datum im Format YYYY-MM-DD' },
+      startTime: { type: 'string', description: 'Startzeit HH:mm' },
+      endTime: { type: 'string', description: 'Endzeit HH:mm (optional)' },
+      location: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          address: { type: 'string' },
+        },
+      },
+      price: { type: 'number', description: 'Preis in Euro oder null' },
+      priceString: { type: 'string', description: 'Original-Preisangabe' },
+      imageUrl: { type: 'string', description: 'Event-Bild URL' },
+      sourceUrl: { type: 'string', description: 'Link zum Original-Event' },
+      category: { type: 'string', description: 'Kategorie (Konzert, Party, etc.)' },
+    },
+    required: ['title', 'date'],
+  },
+};
+```
 
-Analysiere das HTML und extrahiere ALLE Events mit folgenden Feldern:
-- title: Titel des Events
-- description: Beschreibung (falls vorhanden)
-- location: Adresse/Veranstaltungsort
-- date: Datum im Format YYYY-MM-DD
-- startTime: Startzeit im Format HH:mm (falls vorhanden)
-- endTime: Endzeit im Format HH:mm (falls vorhanden)
-- price: Preis als Zahl oder null
-- imageUrl: Bild-URL (falls vorhanden)
-- sourceUrl: Link zum Event (falls vorhanden)
+---
 
-Wichtige Regeln:
-1. Extrahiere nur tatsächliche Events, keine Werbung
-2. Konvertiere deutsche Datumsformate zu ISO
-3. Füge fehlende Jahreszahlen hinzu (aktuelles Jahr)
-4. Setze leere Felder auf null, nicht auf leere Strings
+### Ansatz 2: DeepSeek-V3 (Günstigste Cloud-Option)
+
+**Vorteile:**
+- ✅ Extrem günstig ($0.07-0.27/1M Input)
+- ✅ Gute Qualität für strukturierte Extraktion
+- ✅ OpenAI-kompatible API
+
+**Implementierung:**
+
+```typescript
+// src/events/infrastructure/llm/deepseek-extractor.service.ts
+import OpenAI from 'openai';
+
+@Injectable()
+export class DeepSeekExtractorService {
+  private readonly client: OpenAI;
+
+  constructor() {
+    this.client = new OpenAI({
+      baseURL: 'https://api.deepseek.com',
+      apiKey: process.env.DEEPSEEK_API_KEY,
+    });
+  }
+
+  async extractEvents(html: string): Promise<ExtractedEvent[]> {
+    const response = await this.client.chat.completions.create({
+      model: 'deepseek-chat',
+      messages: [
+        {
+          role: 'system',
+          content: EVENT_EXTRACTION_SYSTEM_PROMPT,
+        },
+        {
+          role: 'user',
+          content: `Extrahiere alle Events aus folgendem HTML:\n\n${this.cleanHtml(html)}`,
+        },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0,
+    });
+
+    const content = response.choices[0].message.content;
+    return JSON.parse(content).events;
+  }
+}
+```
+
+---
+
+### Ansatz 3: Lokales LLM mit Ollama (Kostenlos)
+
+**Vorteile:**
+- ✅ **Komplett kostenlos** (keine API-Kosten)
+- ✅ Datenschutz (Daten verlassen Server nicht)
+- ✅ Keine Rate-Limits
+- ✅ Structured Output seit Dezember 2024
+
+**Nachteile:**
+- ❌ Erfordert GPU-Server (8-16GB VRAM empfohlen)
+- ❌ Langsamere Inferenz als Cloud
+- ❌ Selbst-Hosting erforderlich
+
+**Empfohlene lokale Modelle:**
+
+| Modell | VRAM | Qualität | Geschwindigkeit |
+|--------|------|----------|-----------------|
+| **Llama 3.2 3B** | 4GB | ⭐⭐ | Schnell |
+| **Mistral 7B** | 8GB | ⭐⭐⭐ | Mittel |
+| **Llama 3.1 8B** | 8GB | ⭐⭐⭐⭐ | Mittel |
+| **Mixtral 8x7B** | 24GB | ⭐⭐⭐⭐⭐ | Langsam |
+
+**Implementierung:**
+
+```typescript
+// src/events/infrastructure/llm/ollama-extractor.service.ts
+import { Ollama } from 'ollama';
+
+@Injectable()
+export class OllamaExtractorService {
+  private readonly ollama: Ollama;
+
+  constructor() {
+    this.ollama = new Ollama({
+      host: process.env.OLLAMA_HOST || 'http://localhost:11434',
+    });
+  }
+
+  async extractEvents(html: string): Promise<ExtractedEvent[]> {
+    const response = await this.ollama.chat({
+      model: 'llama3.1:8b',
+      messages: [
+        {
+          role: 'system',
+          content: EVENT_EXTRACTION_SYSTEM_PROMPT,
+        },
+        {
+          role: 'user',
+          content: `Extrahiere alle Events:\n\n${this.cleanHtml(html)}`,
+        },
+      ],
+      format: EVENT_ARRAY_SCHEMA,
+      options: {
+        temperature: 0,
+      },
+    });
+
+    return JSON.parse(response.message.content);
+  }
+}
+```
+
+**Docker-Setup für Ollama:**
+
+```yaml
+# docker-compose.ollama.yml
+services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+volumes:
+  ollama_data:
+```
+
+---
+
+### Ansatz 4: Hybrid-Strategie (Empfohlen für Produktion)
+
+Kombiniere mehrere Ansätze für optimale Kosten und Zuverlässigkeit:
+
+```typescript
+// src/events/infrastructure/llm/hybrid-extractor.service.ts
+@Injectable()
+export class HybridExtractorService {
+  private readonly extractors: LlmExtractor[];
+
+  constructor(
+    private readonly geminiExtractor: GeminiExtractorService,
+    private readonly ollamaExtractor: OllamaExtractorService,
+    private readonly puppeteerFallback: ScraperService,
+  ) {
+    // Priorisierte Reihenfolge
+    this.extractors = [
+      { name: 'gemini', service: geminiExtractor },
+      { name: 'ollama', service: ollamaExtractor },
+    ];
+  }
+
+  async extractEvents(url: string): Promise<ExtractedEvent[]> {
+    const html = await this.fetchHtml(url);
+
+    // Versuche LLM-Extraktoren in Reihenfolge
+    for (const extractor of this.extractors) {
+      try {
+        const events = await extractor.service.extractEvents(html);
+        if (events.length > 0) {
+          this.logger.log(`${extractor.name} erfolgreich: ${events.length} Events`);
+          return events;
+        }
+      } catch (error) {
+        this.logger.warn(`${extractor.name} fehlgeschlagen: ${error.message}`);
+      }
+    }
+
+    // Fallback zu klassischem Scraper
+    this.logger.log('Fallback zu Puppeteer-Scraper');
+    return this.puppeteerFallback.scrapeEventsFromUrl(url);
+  }
+}
+```
+
+**Strategie-Matrix:**
+
+| Szenario | Primär | Fallback 1 | Fallback 2 |
+|----------|--------|------------|------------|
+| **Kostenoptimiert** | Ollama (lokal) | Gemini Free Tier | Puppeteer |
+| **Qualitätsoptimiert** | Gemini Flash | DeepSeek | Puppeteer |
+| **Maximal günstig** | Ollama (lokal) | Puppeteer | - |
+
+---
+
+### Extraktions-Prompt (Optimiert für Event-Daten)
+
+```typescript
+const EVENT_EXTRACTION_SYSTEM_PROMPT = `
+Du bist ein Experte für die Extraktion von Veranstaltungsdaten aus HTML.
+
+AUFGABE:
+Analysiere das HTML und extrahiere ALLE erkennbaren Events/Veranstaltungen.
+
+REGELN:
+1. Extrahiere nur echte Events, keine Werbung oder Navigation
+2. Konvertiere deutsche Datumsformate zu ISO (YYYY-MM-DD)
+3. Füge fehlendes Jahr hinzu (aktuelles Jahr: ${new Date().getFullYear()})
+4. Zeiten im Format HH:mm
+5. Preise als Zahl in Euro (0 für kostenlos, null wenn unbekannt)
+6. Leere Felder als null, nicht als leere Strings
+7. Absolute URLs für Bilder und Links
+
+WICHTIGE HINWEISE:
+- "Eintritt frei", "kostenlos", "free" → price: 0
+- "ab X€", "X€ - Y€" → price: niedrigster Wert, priceString: Original
+- Bei Datumsbereich: Erstelle separate Einträge pro Tag
+- Kategorien: Konzert, Party, Theater, Ausstellung, Sport, Kinder, Sonstiges
+
+Antworte NUR mit einem JSON-Array von Events.
 `;
+```
+
+---
+
+### HTML-Bereinigung (Wichtig für Token-Effizienz)
+
+```typescript
+// src/events/infrastructure/llm/html-cleaner.ts
+export class HtmlCleaner {
+  /**
+   * Bereinigt HTML für LLM-Verarbeitung
+   * Reduziert Token-Verbrauch um 60-80%
+   */
+  static clean(html: string): string {
+    let cleaned = html;
+
+    // 1. Entferne Script und Style Tags
+    cleaned = cleaned.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+    cleaned = cleaned.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
+
+    // 2. Entferne HTML-Kommentare
+    cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, '');
+
+    // 3. Entferne irrelevante Bereiche
+    cleaned = cleaned.replace(/<(header|footer|nav|aside|noscript)[^>]*>[\s\S]*?<\/\1>/gi, '');
+
+    // 4. Entferne Data-Attribute und Event-Handler
+    cleaned = cleaned.replace(/\s(data-[a-z-]+|on[a-z]+)="[^"]*"/gi, '');
+
+    // 5. Entferne leere Tags
+    cleaned = cleaned.replace(/<(\w+)[^>]*>\s*<\/\1>/g, '');
+
+    // 6. Komprimiere Whitespace
+    cleaned = cleaned.replace(/\s+/g, ' ');
+
+    // 7. Entferne übermäßige Attribute
+    cleaned = cleaned.replace(/\s(class|id|style)="[^"]*"/gi, (match, attr) => {
+      // Behalte nur relevante Klassen
+      if (attr === 'class' && /event|date|time|title|location|price/i.test(match)) {
+        return match;
+      }
+      return '';
+    });
+
+    return cleaned.trim();
+  }
+
+  /**
+   * Extrahiert nur den relevanten Content-Bereich
+   */
+  static extractMainContent(html: string): string {
+    // Versuche main, article oder content div zu finden
+    const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+    if (mainMatch) return this.clean(mainMatch[1]);
+
+    const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+    if (articleMatch) return this.clean(articleMatch[1]);
+
+    // Fallback: Gesamtes HTML bereinigen
+    return this.clean(html);
+  }
+}
+```
+
+---
+
+### Kosten-Monitoring
+
+```typescript
+// src/events/infrastructure/llm/cost-tracker.service.ts
+@Injectable()
+export class CostTrackerService {
+  private costs: Map<string, number> = new Map();
+
+  trackUsage(model: string, inputTokens: number, outputTokens: number): void {
+    const pricing = MODEL_PRICING[model];
+    const cost = 
+      (inputTokens / 1_000_000) * pricing.input +
+      (outputTokens / 1_000_000) * pricing.output;
+
+    const current = this.costs.get(model) || 0;
+    this.costs.set(model, current + cost);
+
+    this.logger.log(`${model}: +$${cost.toFixed(4)} (Gesamt: $${(current + cost).toFixed(2)})`);
+  }
+
+  getMonthlyCosts(): Record<string, number> {
+    return Object.fromEntries(this.costs);
+  }
+}
+
+const MODEL_PRICING = {
+  'gemini-2.0-flash': { input: 0.10, output: 0.40 },
+  'deepseek-chat': { input: 0.27, output: 1.10 },
+  'mistral-small': { input: 0.075, output: 0.20 },
+  'ollama': { input: 0, output: 0 },
+};
 ```
 
 ---
 
 ## 📅 Implementierungsplan
 
-### Phase 1: Fundament (1-2 Wochen)
+### Phase 1: LLM-Infrastruktur (1 Woche)
 
-- [ ] OpenAI Service integrieren
-- [ ] LLM-Scraper-Service implementieren
-- [ ] Event-Schema für Structured Outputs definieren
-- [ ] HTML-Bereinigungs-Utility erstellen
+- [ ] `@google/generative-ai` Package installieren
+- [ ] `GeminiExtractorService` implementieren
+- [ ] HTML-Cleaner entwickeln
+- [ ] JSON-Schema für Events definieren
+- [ ] Unit-Tests schreiben
 
-### Phase 2: API-Integration (1 Woche)
+### Phase 2: Integration & Fallback (1 Woche)
 
-- [ ] Eventbrite API Client implementieren
-- [ ] OAuth2-Flow für Eventbrite
-- [ ] API-Response zu Event-Mapping
+- [ ] `HybridExtractorService` implementieren
+- [ ] Fallback zu bestehenden Scrapern einbauen
+- [ ] Error-Handling und Retry-Logik
+- [ ] Kosten-Tracking
 
-### Phase 3: Admin-Frontend (1-2 Wochen)
+### Phase 3: Admin-Frontend Integration (1-2 Wochen)
 
-- [ ] URL-Eingabe-Formular
-- [ ] Quellen-Auswahl (Auto-Detect)
-- [ ] Event-Vorschau mit Bearbeitungsmöglichkeit
+- [ ] API-Endpoint für URL-basierte Extraktion
+- [ ] Event-Vorschau im Admin-Panel
+- [ ] Manuelles Bearbeiten vor Import
 - [ ] Batch-Import-Funktion
 
 ### Phase 4: Optimierung (1 Woche)
 
 - [ ] Caching für wiederkehrende URLs
-- [ ] Rate-Limiting implementieren
-- [ ] Fehler-Monitoring und Alerts
-- [ ] A/B-Testing LLM vs. Puppeteer
+- [ ] Prompt-Optimierung basierend auf Ergebnissen
+- [ ] Ollama-Setup als kostenfreie Alternative
+- [ ] Monitoring-Dashboard
+
+---
+
+## ❌ Abgelehnte Alternativen
+
+### 1. Event-APIs (Eventbrite, Eventfrog, etc.)
+
+**Grund der Ablehnung:**
+- Begrenzte Quellen: Nur Events von API-Partnern verfügbar
+- Viele lokale Veranstalter nutzen keine dieser Plattformen
+- Einschränkung auf wenige Anbieter entspricht nicht dem Ziel, viele verschiedene Quellen zu unterstützen
+
+**Dokumentation:**
+- Eventbrite API: Kostenlos, aber nur Eventbrite-Events
+- Eventfrog API: Primär CH/DE, begrenzte Abdeckung
+- AllEvents API: Aggregator, aber Freemium mit Limits
+
+### 2. Scraping-as-a-Service (Firecrawl, Browserless, etc.)
+
+**Grund der Ablehnung:**
+- **Laufende Kosten** ab $16-99/Monat
+- Abhängigkeit von Drittanbieter
+- Keine Kostenkontrolle bei steigender Nutzung
+
+**Preise (Stand Januar 2026):**
+| Service | Free Tier | Paid |
+|---------|-----------|------|
+| Firecrawl | 500 Credits | $16+/Mo |
+| Browserless | 6h/Mo | $99/Mo |
+| ScrapingBee | 1000 Credits | $49/Mo |
+
+### 3. Reines Puppeteer-Refactoring
+
+**Grund der Ablehnung:**
+- Löst das Grundproblem (Fragilität) nicht
+- Weiterhin hoher Wartungsaufwand bei Strukturänderungen
+- Keine semantische Intelligenz
+
+**Aber:** Wird als Fallback beibehalten für Fälle, in denen LLM-Extraktion fehlschlägt.
 
 ---
 
 ## 📝 Fazit
 
-Der aktuelle Puppeteer-basierte Ansatz ist funktional, aber **nicht nachhaltig**. Die empfohlene Hybrid-Lösung bietet:
+Der **LLM-basierte Ansatz mit Gemini Flash 2.0** (oder Ollama für Kosten=0) bietet:
 
-1. **Bessere Zuverlässigkeit** durch LLM-basierte Extraktion
-2. **Geringere Wartung** durch semantisches Verständnis
-3. **Höhere Datenqualität** durch Normalisierung
-4. **Moderate Kosten** (~€15-25/Monat)
+1. **Robustheit** gegen HTML-Strukturänderungen
+2. **Einheitliche Implementierung** für alle Quellen
+3. **Geringe Kosten** (~€10-15/Monat oder kostenlos mit Ollama)
+4. **Zukunftssicher** durch semantisches Verständnis
 
-Der wichtigste Schritt ist die **Integration des Admin-Frontends** mit dem Backend, um manuelle Überprüfung und Korrekturen vor dem Import zu ermöglichen – unabhängig vom gewählten Extraktionsansatz.
+Der bestehende Puppeteer-Ansatz bleibt als **Fallback** erhalten und wird nur aktiviert, wenn die LLM-Extraktion fehlschlägt.
 
 ---
 
 ## 🔗 Referenzen
 
-- [OpenAI Structured Outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/)
-- [Eventbrite API Dokumentation](https://www.eventbrite.com/platform/api)
-- [Firecrawl AI Extraction](https://firecrawl.dev)
-- [Puppeteer Dokumentation](https://pptr.dev)
+- [Gemini API Dokumentation](https://ai.google.dev/gemini-api/docs)
+- [Gemini Structured Output](https://ai.google.dev/gemini-api/docs/structured-output)
+- [DeepSeek API](https://api-docs.deepseek.com/)
+- [Ollama Structured Outputs](https://ollama.com/blog/structured-outputs)
+- [Mistral JSON Mode](https://docs.mistral.ai/capabilities/structured_output/json_mode)

--- a/docs/scraping-analysis.md
+++ b/docs/scraping-analysis.md
@@ -1,0 +1,413 @@
+# Event-Scraping Analyse & Empfehlungen
+
+**Erstellt:** 09. Januar 2026  
+**Branch:** `feature/scraping-analysis-improvement`  
+**Status:** Analyse-Phase
+
+---
+
+## 📋 Inhaltsverzeichnis
+
+1. [Executive Summary](#executive-summary)
+2. [Aktuelle Implementierung](#aktuelle-implementierung)
+3. [Identifizierte Probleme](#identifizierte-probleme)
+4. [Alternative Ansätze](#alternative-ansätze)
+5. [Empfehlung](#empfehlung)
+6. [Implementierungsplan](#implementierungsplan)
+
+---
+
+## 🎯 Executive Summary
+
+Die aktuelle Scraping-Implementierung basiert auf **Puppeteer** mit hartcodierten CSS-Selektoren für 5 Event-Quellen. Dieser Ansatz ist **fragil und wartungsintensiv**, da HTML-Strukturänderungen der Zielseiten sofortige Code-Anpassungen erfordern.
+
+**Empfehlung:** Hybrid-Ansatz mit:
+1. **Primär:** LLM-basierte Extraktion (OpenAI GPT-4o mit Structured Outputs)
+2. **Sekundär:** Offizielle APIs wo verfügbar (Eventbrite API, Eventfrog API)
+3. **Fallback:** Optimierte Puppeteer-Scraper als Backup
+
+**Geschätzte Kosten:** ~€10-30/Monat bei moderater Nutzung
+
+---
+
+## 📊 Aktuelle Implementierung
+
+### Architektur-Übersicht
+
+```
+src/events/infrastructure/scraping/
+├── base-scraper.interface.ts    # BaseScraper Interface & ScraperType Enum
+├── scraper.service.ts           # Zentraler Service für alle Scraper
+├── scraper-factory.ts           # Factory Pattern für Scraper-Erstellung
+├── puppeteer.config.ts          # Puppeteer Browser-Konfiguration
+├── eventfinder-scraper.ts       # eventfinder.de Scraper
+├── curt-scraper.ts              # curt.de Scraper
+├── rausgegangen-scraper.ts      # rausgegangen.de Scraper
+├── eventbrite-scraper.ts        # eventbrite.de Scraper
+└── parks-scraper.ts             # Parks-Events Scraper
+```
+
+### Implementierte Scraper
+
+| Scraper | URL | Selektoren | Status |
+|---------|-----|------------|--------|
+| EventFinder | eventfinder.de/nuernberg | `.card.event`, `.titel`, `.datetime-mobile` | ⚠️ Fragil |
+| CURT | curt.de/termine/84 | `.event`, `.time`, `.dat`, `.title a` | ⚠️ Fragil |
+| Rausgegangen | rausgegangen.de/nurnberg | `#horizontal-scroll`, `.event-tile-text` | ⚠️ Fragil |
+| Eventbrite | eventbrite.de | `.event-card`, `.event-card-details` | ⚠️ Fragil |
+| Parks | - | - | 🔍 Zu prüfen |
+
+### Technische Details
+
+**Puppeteer-Konfiguration:**
+- Headless Chrome mit Mobile-Viewport (375x812)
+- Timeout: 60 Sekunden
+- User-Agent: iPhone iOS 14
+- 47 Chrome-Args für Performance-Optimierung
+
+**Datenextraktion:**
+- CSS-Selektoren mit Fallbacks (z.B. `.time, .uhrzeit`)
+- Datumskonvertierung von deutschem Format zu ISO
+- Cookie-Banner-Handling pro Seite
+
+---
+
+## ⚠️ Identifizierte Probleme
+
+### 1. **Hohe Fragilität (Kritisch)**
+
+Die Selektoren sind extrem spezifisch und brechen bei kleinsten HTML-Änderungen:
+
+```typescript
+// eventfinder-scraper.ts - Beispiel fragiler Selektoren
+const title = element.querySelector('.titel')?.textContent?.trim() || '';
+const datetimeContainer = element.querySelector('.datetime-mobile');
+const locationText = element.querySelector('.card-body-footer')?.textContent?.trim() || '';
+```
+
+**Problem:** Wenn eventfinder.de `.titel` zu `.event-title` ändert, bricht der Scraper.
+
+### 2. **Inkonsistente Datenqualität**
+
+- Fehlende Beschreibungen (Eventbrite: `description: ''`)
+- Unvollständige Geodaten (`latitude: 0, longitude: 0`)
+- Inkonsistente Zeitbehandlung (`to: ''` vs `to: fromTime`)
+- Fehlende Bilder/URLs
+
+### 3. **Performance-Probleme**
+
+- Puppeteer-Browserinstanz pro Request
+- Sequentielle Datumsbereichsverarbeitung
+- Hoher Ressourcenverbrauch (RAM/CPU)
+
+### 4. **Wartungsaufwand**
+
+- 5 separate Scraper mit jeweils eigener Logik
+- Keine zentrale Fehlerbehandlung
+- Duplizierter Code für Datumsparsing
+
+### 5. **Skalierbarkeit**
+
+- Neue Quellen erfordern komplette Scraper-Implementierung
+- Keine dynamische Anpassung an Seitenänderungen
+- Rate-Limiting nicht implementiert
+
+---
+
+## 🔄 Alternative Ansätze
+
+### Option A: LLM-basierte Extraktion (Empfohlen)
+
+**Technologie:** OpenAI GPT-4o mit Structured Outputs
+
+**Konzept:**
+```typescript
+// Beispiel: LLM-basierte Event-Extraktion
+const response = await openai.chat.completions.create({
+  model: "gpt-4o",
+  response_format: {
+    type: "json_schema",
+    json_schema: {
+      name: "event_extraction",
+      schema: eventSchema
+    }
+  },
+  messages: [{
+    role: "user",
+    content: `Extrahiere alle Events aus folgendem HTML. 
+              Gib nur valides JSON zurück.\n\n${pageContent}`
+  }]
+});
+```
+
+**Vorteile:**
+- ✅ Robust gegen HTML-Strukturänderungen
+- ✅ Versteht Kontext und semantische Bedeutung
+- ✅ Einheitliche Implementierung für alle Quellen
+- ✅ Automatische Normalisierung der Daten
+- ✅ 100% valide JSON-Outputs garantiert
+
+**Nachteile:**
+- ❌ API-Kosten (~$0.01-0.03 pro Seite)
+- ❌ Latenz (~2-5s pro Anfrage)
+- ❌ Token-Limits bei großen Seiten
+
+**Geschätzte Kosten:**
+- GPT-4o: ~$2.50/1M input tokens, ~$10/1M output tokens
+- Bei 100 Seiten/Tag: ~$5-15/Monat
+
+### Option B: Event-APIs nutzen
+
+**Verfügbare APIs:**
+
+| API | Kostenlos | Umfang | Relevanz |
+|-----|-----------|--------|----------|
+| **Eventbrite API** | Ja (Rate Limits) | Weltweit | ⭐⭐⭐ Hoch |
+| **Eventfrog API** | Ja | CH/DE | ⭐⭐ Mittel |
+| **AllEvents API** | Freemium | 200M+ Events | ⭐⭐ Mittel |
+| **PredictHQ** | Freemium | Aggregator | ⭐ Niedrig |
+
+**Eventbrite API Beispiel:**
+```typescript
+// GET /events/search/
+const response = await fetch(
+  'https://www.eventbriteapi.com/v3/events/search/?location.address=Nürnberg',
+  { headers: { 'Authorization': `Bearer ${EVENTBRITE_TOKEN}` }}
+);
+```
+
+**Vorteile:**
+- ✅ Strukturierte, zuverlässige Daten
+- ✅ Keine Wartung bei Webseiten-Änderungen
+- ✅ Offizielle Bilder, Beschreibungen, Geodaten
+- ✅ Pagination und Filtering eingebaut
+
+**Nachteile:**
+- ❌ Begrenzte Quellen (nur API-Partner)
+- ❌ Rate Limits
+- ❌ Nicht alle lokalen Events verfügbar
+
+### Option C: Scraping-as-a-Service
+
+**Anbieter:**
+
+| Service | Free Tier | Preis | Features |
+|---------|-----------|-------|----------|
+| **Firecrawl** | 500 Credits | $16/Mo | AI-Extraktion, LLM-ready |
+| **Browserless** | 6h/Mo | $99/Mo | Puppeteer-Hosting |
+| **ScrapingBee** | 1000 Credits | $49/Mo | Residential Proxies |
+| **Crawl4AI** | Open Source | Kostenlos | Self-hosted |
+
+**Firecrawl Beispiel:**
+```typescript
+import Firecrawl from '@mendable/firecrawl-js';
+
+const app = new Firecrawl({ apiKey: 'fc-xxx' });
+const result = await app.scrapeUrl('https://eventfinder.de/nuernberg', {
+  formats: ['extract'],
+  extract: {
+    schema: eventSchema,
+    systemPrompt: 'Extrahiere Event-Daten in deutscher Sprache'
+  }
+});
+```
+
+**Vorteile:**
+- ✅ Managed Infrastructure
+- ✅ AI-basierte Extraktion integriert
+- ✅ Proxy-Rotation, CAPTCHA-Handling
+
+**Nachteile:**
+- ❌ Laufende Kosten
+- ❌ Abhängigkeit von Drittanbieter
+
+### Option D: Optimierter aktueller Ansatz
+
+**Verbesserungen am bestehenden System:**
+
+1. **Resiliente Selektoren:**
+```typescript
+// Fallback-Ketten für mehr Robustheit
+const title = element.querySelector('.titel, .title, h2, h3, [class*="title"]')?.textContent;
+```
+
+2. **Zentrale Konfiguration:**
+```typescript
+// Selektoren in Config-Dateien auslagern
+const scraperConfig = {
+  eventfinder: {
+    selectors: {
+      container: '.card.event',
+      title: '.titel',
+      // ...
+    }
+  }
+};
+```
+
+3. **Health-Checks & Alerts:**
+```typescript
+// Automatische Erkennung von Strukturänderungen
+if (events.length === 0 && page.content().includes('event')) {
+  this.notifyStructureChange('eventfinder');
+}
+```
+
+---
+
+## ✅ Empfehlung: Hybrid-Ansatz
+
+### Strategie
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Admin-Oberfläche (Frontend)                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │ URL eingeben │→ │ Quelle wählen│→ │ Events prüfen/import │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│                    Backend Scraping Service                      │
+│                                                                   │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
+│  │ 1. API      │ → │ 2. LLM      │ → │ 3. Fallback         │  │
+│  │ (Eventbrite)│    │ (GPT-4o)   │    │ (Puppeteer)         │  │
+│  └─────────────┘    └─────────────┘    └─────────────────────┘  │
+│         ↓                  ↓                    ↓                │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │              Unified Event Normalizer                        ││
+│  │  - Deduplizierung                                            ││
+│  │  - Geocoding (Google Maps API)                               ││
+│  │  - Kategorie-Mapping                                         ││
+│  └─────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Priorisierung der Quellen
+
+1. **Eventbrite API** (Kostenlos, strukturiert, ~40% der Events)
+2. **LLM-Extraktion** (Flexibel, ~50% der Events)
+3. **Puppeteer Fallback** (Spezialfälle, ~10% der Events)
+
+### Kostenanalyse (Monatlich)
+
+| Komponente | Nutzung | Kosten |
+|------------|---------|--------|
+| OpenAI GPT-4o | ~200 Seiten | ~$10-15 |
+| Eventbrite API | Kostenlos | $0 |
+| Puppeteer (Serverless) | ~50 Seiten | ~$2-5 |
+| Google Geocoding | ~500 Adressen | ~$2-5 |
+| **Gesamt** | | **~$15-25/Monat** |
+
+### Technische Implementierung
+
+**Neuer LLM-basierter Scraper:**
+
+```typescript
+// src/events/infrastructure/scraping/llm-scraper.service.ts
+@Injectable()
+export class LlmScraperService {
+  constructor(
+    private readonly openaiService: OpenAiService,
+    private readonly puppeteerManager: PuppeteerManager,
+  ) {}
+
+  async extractEventsFromUrl(url: string): Promise<Event[]> {
+    // 1. HTML abrufen (mit Puppeteer für JS-rendered Seiten)
+    const html = await this.fetchPageContent(url);
+    
+    // 2. HTML bereinigen (Script/Style Tags entfernen)
+    const cleanedHtml = this.cleanHtml(html);
+    
+    // 3. LLM-Extraktion mit strukturiertem Output
+    const events = await this.openaiService.extractStructured<Event[]>({
+      model: 'gpt-4o',
+      systemPrompt: EVENT_EXTRACTION_PROMPT,
+      content: cleanedHtml,
+      schema: eventArraySchema,
+    });
+    
+    // 4. Nachbearbeitung (Geocoding, Kategorie-Mapping)
+    return this.normalizeEvents(events);
+  }
+}
+```
+
+**Event-Extraktions-Prompt:**
+
+```typescript
+const EVENT_EXTRACTION_PROMPT = `
+Du bist ein Experte für die Extraktion von Event-Daten aus HTML.
+
+Analysiere das HTML und extrahiere ALLE Events mit folgenden Feldern:
+- title: Titel des Events
+- description: Beschreibung (falls vorhanden)
+- location: Adresse/Veranstaltungsort
+- date: Datum im Format YYYY-MM-DD
+- startTime: Startzeit im Format HH:mm (falls vorhanden)
+- endTime: Endzeit im Format HH:mm (falls vorhanden)
+- price: Preis als Zahl oder null
+- imageUrl: Bild-URL (falls vorhanden)
+- sourceUrl: Link zum Event (falls vorhanden)
+
+Wichtige Regeln:
+1. Extrahiere nur tatsächliche Events, keine Werbung
+2. Konvertiere deutsche Datumsformate zu ISO
+3. Füge fehlende Jahreszahlen hinzu (aktuelles Jahr)
+4. Setze leere Felder auf null, nicht auf leere Strings
+`;
+```
+
+---
+
+## 📅 Implementierungsplan
+
+### Phase 1: Fundament (1-2 Wochen)
+
+- [ ] OpenAI Service integrieren
+- [ ] LLM-Scraper-Service implementieren
+- [ ] Event-Schema für Structured Outputs definieren
+- [ ] HTML-Bereinigungs-Utility erstellen
+
+### Phase 2: API-Integration (1 Woche)
+
+- [ ] Eventbrite API Client implementieren
+- [ ] OAuth2-Flow für Eventbrite
+- [ ] API-Response zu Event-Mapping
+
+### Phase 3: Admin-Frontend (1-2 Wochen)
+
+- [ ] URL-Eingabe-Formular
+- [ ] Quellen-Auswahl (Auto-Detect)
+- [ ] Event-Vorschau mit Bearbeitungsmöglichkeit
+- [ ] Batch-Import-Funktion
+
+### Phase 4: Optimierung (1 Woche)
+
+- [ ] Caching für wiederkehrende URLs
+- [ ] Rate-Limiting implementieren
+- [ ] Fehler-Monitoring und Alerts
+- [ ] A/B-Testing LLM vs. Puppeteer
+
+---
+
+## 📝 Fazit
+
+Der aktuelle Puppeteer-basierte Ansatz ist funktional, aber **nicht nachhaltig**. Die empfohlene Hybrid-Lösung bietet:
+
+1. **Bessere Zuverlässigkeit** durch LLM-basierte Extraktion
+2. **Geringere Wartung** durch semantisches Verständnis
+3. **Höhere Datenqualität** durch Normalisierung
+4. **Moderate Kosten** (~€15-25/Monat)
+
+Der wichtigste Schritt ist die **Integration des Admin-Frontends** mit dem Backend, um manuelle Überprüfung und Korrekturen vor dem Import zu ermöglichen – unabhängig vom gewählten Extraktionsansatz.
+
+---
+
+## 🔗 Referenzen
+
+- [OpenAI Structured Outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/)
+- [Eventbrite API Dokumentation](https://www.eventbrite.com/platform/api)
+- [Firecrawl AI Extraction](https://firecrawl.dev)
+- [Puppeteer Dokumentation](https://pptr.dev)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "firebase-admin": "^13.5.0",
         "luxon": "^3.6.1",
         "node-fetch": "^2.7.0",
+        "openai": "^4.104.0",
         "passkit-generator": "^3.3.1",
         "puppeteer": "^24.9.0",
         "reflect-metadata": "^0.2.2",
@@ -3758,7 +3759,6 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4302,7 +4302,6 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -4375,6 +4374,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -6802,7 +6813,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -7454,6 +7464,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
     "node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -7473,6 +7489,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/formidable": {
@@ -8097,6 +8126,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -10594,6 +10632,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-downloader-helper": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz",
@@ -10785,6 +10843,51 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -13841,6 +13944,15 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "firebase-admin": "^13.5.0",
     "luxon": "^3.6.1",
     "node-fetch": "^2.7.0",
+    "openai": "^4.104.0",
     "passkit-generator": "^3.3.1",
     "puppeteer": "^24.9.0",
     "reflect-metadata": "^0.2.2",

--- a/src/events/dto/create-event.dto.ts
+++ b/src/events/dto/create-event.dto.ts
@@ -13,6 +13,7 @@ import {
 } from 'class-validator';
 import { DailyTimeSlot } from '../interfaces/event.interface';
 import { DailyTimeSlotDTO } from './daily-time-slot.dto';
+import { IsValidCategory } from './validators/is-valid-category.validator';
 
 export class CreateEventDto {
   @IsString()
@@ -47,6 +48,7 @@ export class CreateEventDto {
 
   @IsString()
   @IsNotEmpty()
+  @IsValidCategory()
   public readonly categoryId: string;
 
   @IsOptional()

--- a/src/events/dto/llm-scrape.dto.ts
+++ b/src/events/dto/llm-scrape.dto.ts
@@ -1,0 +1,21 @@
+import { IsString, IsUrl, IsOptional, IsBoolean } from 'class-validator';
+
+/**
+ * DTO für LLM-basierte Event-Extraktion
+ */
+export class LlmScrapeDto {
+  /**
+   * URL der Seite, von der Events extrahiert werden sollen
+   */
+  @IsUrl()
+  @IsString()
+  url: string;
+
+  /**
+   * Ob Fallback zu Puppeteer-Scraper verwendet werden soll
+   * Default: true
+   */
+  @IsOptional()
+  @IsBoolean()
+  useFallback?: boolean = true;
+}

--- a/src/events/dto/validators/is-valid-category.validator.ts
+++ b/src/events/dto/validators/is-valid-category.validator.ts
@@ -1,0 +1,44 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { Injectable } from '@nestjs/common';
+import { EventCategoriesService } from '../../../event-categories/services/event-categories.service';
+
+@ValidatorConstraint({ name: 'isValidCategory', async: true })
+@Injectable()
+export class IsValidCategoryConstraint implements ValidatorConstraintInterface {
+  constructor(private readonly eventCategoriesService: EventCategoriesService) {}
+
+  async validate(categoryId: any, args: ValidationArguments): Promise<boolean> {
+    if (typeof categoryId !== 'string' || !categoryId) {
+      return false;
+    }
+
+    try {
+      const category = await this.eventCategoriesService.findOne(categoryId);
+      return category !== null;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return 'categoryId muss eine gültige Event-Kategorie sein';
+  }
+}
+
+export function IsValidCategory(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidCategoryConstraint,
+    });
+  };
+}

--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -447,38 +447,4 @@ describe('EventsController', () => {
     });
   });
 
-  describe('scrapeEvents', () => {
-    it('should return events from scraper', async () => {
-      const mockScraper = {
-        scrapeEvents: jest.fn().mockResolvedValue([mockEvent])
-      };
-      mockScraperService.getScraper.mockReturnValue(mockScraper);
-
-      const result = await controller.scrapeEvents(
-        ScraperType.EVENTFINDER,
-        null,
-        '2024-03-20',
-        '2024-03-27',
-        10
-      );
-
-      expect(result).toEqual([mockEvent]);
-      expect(mockScraperService.getScraper).toHaveBeenCalledWith(ScraperType.EVENTFINDER);
-      expect(mockScraper.scrapeEvents).toHaveBeenCalledWith({
-        category: null,
-        startDate: expect.any(Date),
-        endDate: expect.any(Date),
-        maxResults: 10
-      });
-    });
-
-    it('should throw error for invalid scraper type', async () => {
-      await expect(controller.scrapeEvents(
-        'INVALID_TYPE' as ScraperType,
-        null,
-        '2024-03-20',
-        '2024-03-27'
-      )).rejects.toThrow('Ungültiger Scraper-Typ');
-    });
-  });
 });

--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -5,6 +5,8 @@ import { ScraperService } from './infrastructure/scraping/scraper.service';
 import { FirebaseStorageService } from '../firebase/firebase-storage.service';
 import { UsersService } from '../users/users.service';
 import { BusinessesService } from '../businesses/application/services/businesses.service';
+import { HybridExtractorService } from './infrastructure/llm/hybrid-extractor.service';
+import { CostTrackerService } from './infrastructure/llm/cost-tracker.service';
 import { CreateEventDto } from './dto/create-event.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Event } from './interfaces/event.interface';
@@ -49,6 +51,16 @@ describe('EventsController', () => {
     addEventToBusiness: jest.fn(),
   };
 
+  const mockHybridExtractorService = {
+    scrapeEventsFromUrl: jest.fn(),
+  };
+
+  const mockCostTrackerService = {
+    getMonthlyCosts: jest.fn().mockReturnValue({ costs: {}, total: 0, currency: 'USD' }),
+    getTokenUsage: jest.fn().mockReturnValue({ usage: {}, totals: { input: 0, output: 0, total: 0 } }),
+    trackUsage: jest.fn(),
+  };
+
   const mockEvent: Event = {
     id: '1',
     title: 'Test Event',
@@ -88,6 +100,14 @@ describe('EventsController', () => {
         {
           provide: BusinessesService,
           useValue: mockBusinessesService,
+        },
+        {
+          provide: HybridExtractorService,
+          useValue: mockHybridExtractorService,
+        },
+        {
+          provide: CostTrackerService,
+          useValue: mockCostTrackerService,
         },
       ],
     }).compile();

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -16,6 +16,7 @@ import {
   Query,
   ParseEnumPipe,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { EventsService } from './events.service';
 import { Event } from './interfaces/event.interface';
 import { CreateEventDto } from './dto/create-event.dto';
@@ -24,9 +25,15 @@ import { FileValidationPipe } from '../core/pipes/file-validation.pipe';
 import { FirebaseStorageService } from '../firebase/firebase-storage.service';
 import { UsersService } from '../users/users.service';
 import { BusinessesService } from '../businesses/application/services/businesses.service';
-import { EventCategory } from './enums/event-category.enum';
 import { ScraperService } from './infrastructure/scraping/scraper.service';
-import { ScraperOptions, ScraperType } from './infrastructure/scraping/base-scraper.interface';
+import {
+  ScraperOptions,
+  ScraperType,
+  ScraperResult,
+} from './infrastructure/scraping/base-scraper.interface';
+import { HybridExtractorService } from './infrastructure/llm/hybrid-extractor.service';
+import { CostTrackerService } from './infrastructure/llm/cost-tracker.service';
+import { LlmScrapeDto } from './dto/llm-scrape.dto';
 
 @Controller('events')
 export class EventsController {
@@ -39,6 +46,8 @@ export class EventsController {
     private readonly usersService: UsersService,
     private readonly businessesService: BusinessesService,
     private readonly scraperService: ScraperService,
+    private readonly hybridExtractor: HybridExtractorService,
+    private readonly costTracker: CostTrackerService,
   ) {
     this.logger.log('EventsController initialized');
   }
@@ -49,69 +58,6 @@ export class EventsController {
     return this.eventsService.getAll();
   }
 
-  /**
-   * Generischer Endpunkt zum Scrapen von Events
-   *
-   * @param type - Der Scraper-Typ (EVENTFINDER, CURT)
-   * @param category - Die Event-Kategorie
-   * @param startDate - Startdatum (YYYY-MM-DD)
-   * @param endDate - Enddatum (YYYY-MM-DD)
-   * @param maxResults - Maximale Anzahl der Ergebnisse
-   * @returns Array von Events
-   */
-  @Get('scrape')
-  public async scrapeEvents(
-    @Query('type') type: string,
-    @Query('category') category?: string,
-    @Query('startDate') startDateString?: string,
-    @Query('endDate') endDateString?: string,
-    @Query('maxResults') maxResults?: number,
-  ): Promise<Event[]> {
-    this.logger.log(
-      `GET /events/scrape?type=${type}&category=${category}&startDate=${startDateString}&endDate=${endDateString}&maxResults=${maxResults}`,
-    );
-
-    // Validiere den Scraper-Typ
-    const normalizedType = type?.toLowerCase();
-    if (!normalizedType || !Object.values(ScraperType).includes(normalizedType as ScraperType)) {
-      throw new Error('Ungültiger Scraper-Typ');
-    }
-
-    const scraperType = normalizedType as ScraperType;
-
-    // Validiere und parse Datumsangaben
-    const startDate = startDateString ? new Date(startDateString) : new Date();
-    const endDate = endDateString
-      ? new Date(endDateString)
-      : new Date(startDate.getTime() + 7 * 24 * 60 * 60 * 1000); // +7 Tage
-
-    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-      throw new Error('Ungültiges Datum');
-    }
-
-    if (endDate < startDate) {
-      throw new Error('Enddatum muss nach dem Startdatum liegen');
-    }
-
-    // Konvertiere category von 'null' zu null
-    const parsedCategory = category === 'null' ? null : (category as EventCategory);
-
-    // Erstelle Scraper-Optionen
-    const options: ScraperOptions = {
-      category: parsedCategory,
-      startDate,
-      endDate,
-      maxResults: maxResults || 10,
-    };
-
-    // Führe das Scraping durch
-    const scraper = this.scraperService.getScraper(scraperType);
-    if (!scraper) {
-      throw new Error(`Scraper ${scraperType} nicht gefunden`);
-    }
-
-    return scraper.scrapeEvents(options);
-  }
 
   @Get(':id')
   public async getById(@Param('id') id: string): Promise<Event> {
@@ -416,5 +362,105 @@ export class EventsController {
   public async getActiveScrapers(): Promise<ScraperType[]> {
     this.logger.log('GET /events/scrape/active');
     return this.scraperService.getActiveScrapers();
+  }
+
+  /**
+   * LLM-basierte Event-Extraktion von einer URL
+   * Nutzt Mistral Small 3.2 für semantische Extraktion mit Fallback zu Puppeteer
+   *
+   * @param dto - DTO mit URL und Fallback-Option
+   * @returns ScraperResult mit extrahierten Events
+   */
+  @Post('scrape/llm')
+  @ApiOperation({
+    summary: 'Extrahiert Events von einer URL mit LLM-basierter Extraktion',
+    description:
+      'Nutzt Mistral Small 3.2 für semantische Event-Extraktion. Bei Fehlern erfolgt automatisch Fallback zu Puppeteer-Scrapers.',
+  })
+  @ApiBody({ type: LlmScrapeDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Events erfolgreich extrahiert',
+    schema: {
+      type: 'object',
+      properties: {
+        events: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/Event' },
+        },
+        hasMorePages: { type: 'boolean' },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Ungültige URL' })
+  @ApiResponse({ status: 500, description: 'Fehler bei der Extraktion' })
+  public async scrapeEventsWithLlm(@Body() dto: LlmScrapeDto): Promise<ScraperResult> {
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'events.controller.ts:467',message:'scrapeEventsWithLlm entry',data:{url:dto.url,useFallback:dto.useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    // #endregion
+    this.logger.log(
+      `POST /events/scrape/llm - URL: ${dto.url}, Fallback: ${dto.useFallback ?? true}`,
+    );
+
+    if (!dto.url) {
+      throw new Error('URL ist erforderlich');
+    }
+
+    const result = await this.hybridExtractor.scrapeEventsFromUrl(dto.url, { useFallback: dto.useFallback ?? true } as any);
+
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'events.controller.ts:477',message:'scrapeEventsWithLlm exit',data:{eventsCount:result.events.length,hasMorePages:result.hasMorePages},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    // #endregion
+    this.logger.log(`LLM-Scraping abgeschlossen: ${result.events.length} Events gefunden`);
+
+    return result;
+  }
+
+  /**
+   * Gibt monatliche Kosten-Statistiken für LLM-Extraktion zurück
+   */
+  @Get('scrape/llm/costs')
+  @ApiOperation({
+    summary: 'Gibt monatliche Kosten-Statistiken für LLM-Extraktion zurück',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Kosten-Statistiken',
+    schema: {
+      type: 'object',
+      additionalProperties: { type: 'number' },
+      example: { 'mistral-small-latest': 0.15 },
+    },
+  })
+  public async getLlmCosts(): Promise<Record<string, number>> {
+    this.logger.log('GET /events/scrape/llm/costs');
+    return this.costTracker.getMonthlyCosts();
+  }
+
+  /**
+   * Gibt Token-Verbrauch für LLM-Extraktion zurück
+   */
+  @Get('scrape/llm/tokens')
+  @ApiOperation({
+    summary: 'Gibt Token-Verbrauch für LLM-Extraktion zurück',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Token-Verbrauch',
+    schema: {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          input: { type: 'number' },
+          output: { type: 'number' },
+        },
+      },
+      example: { 'mistral-small-latest': { input: 500000, output: 100000 } },
+    },
+  })
+  public async getLlmTokenUsage(): Promise<Record<string, { input: number; output: number }>> {
+    this.logger.log('GET /events/scrape/llm/tokens');
+    return this.costTracker.getTokenUsage();
   }
 }

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -12,9 +12,20 @@ import { ScraperFactory } from './infrastructure/scraping/scraper-factory';
 import { RausgegangenScraper } from './infrastructure/scraping/rausgegangen-scraper';
 import { ParksScraper } from './infrastructure/scraping/parks-scraper';
 import { EventbriteScraper } from './infrastructure/scraping/eventbrite-scraper';
+import { MistralExtractorService } from './infrastructure/llm/mistral-extractor.service';
+import { EventNormalizerService } from './infrastructure/llm/event-normalizer.service';
+import { HybridExtractorService } from './infrastructure/llm/hybrid-extractor.service';
+import { CostTrackerService } from './infrastructure/llm/cost-tracker.service';
+import { EventCategoriesModule } from '../event-categories/event-categories.module';
+import { IsValidCategoryConstraint } from './dto/validators/is-valid-category.validator';
 
 @Module({
-  imports: [FirebaseModule, forwardRef(() => UsersModule), forwardRef(() => BusinessesModule)],
+  imports: [
+    FirebaseModule,
+    forwardRef(() => UsersModule),
+    forwardRef(() => BusinessesModule),
+    EventCategoriesModule,
+  ],
   controllers: [EventsController],
   providers: [
     EventsService,
@@ -26,6 +37,11 @@ import { EventbriteScraper } from './infrastructure/scraping/eventbrite-scraper'
     RausgegangenScraper,
     ParksScraper,
     EventbriteScraper,
+    MistralExtractorService,
+    EventNormalizerService,
+    HybridExtractorService,
+    CostTrackerService,
+    IsValidCategoryConstraint,
   ],
   exports: [EventsService],
 })

--- a/src/events/infrastructure/llm/cost-tracker.service.spec.ts
+++ b/src/events/infrastructure/llm/cost-tracker.service.spec.ts
@@ -20,24 +20,31 @@ describe('CostTrackerService', () => {
     it('should track costs for mistral-small-latest', () => {
       service.trackUsage('mistral-small-latest', 1000000, 500000);
 
-      const costs = service.getMonthlyCosts();
-      expect(costs['mistral-small-latest']).toBeCloseTo(0.175, 3); // (1M * 0.075) + (0.5M * 0.2)
+      const result = service.getMonthlyCosts();
+      expect(result.costs['mistral-small-latest']).toBeCloseTo(0.175, 3); // (1M * 0.075) + (0.5M * 0.2)
+      expect(result.total).toBeCloseTo(0.175, 3);
+      expect(result.currency).toBe('USD');
     });
 
     it('should accumulate costs', () => {
       service.trackUsage('mistral-small-latest', 1000000, 500000);
       service.trackUsage('mistral-small-latest', 1000000, 500000);
 
-      const costs = service.getMonthlyCosts();
-      expect(costs['mistral-small-latest']).toBeCloseTo(0.35, 3);
+      const result = service.getMonthlyCosts();
+      expect(result.costs['mistral-small-latest']).toBeCloseTo(0.35, 3);
+      expect(result.total).toBeCloseTo(0.35, 3);
     });
 
     it('should track token usage', () => {
       service.trackUsage('mistral-small-latest', 1000000, 500000);
 
-      const usage = service.getTokenUsage();
-      expect(usage['mistral-small-latest'].input).toBe(1000000);
-      expect(usage['mistral-small-latest'].output).toBe(500000);
+      const result = service.getTokenUsage();
+      expect(result.usage['mistral-small-latest'].input).toBe(1000000);
+      expect(result.usage['mistral-small-latest'].output).toBe(500000);
+      expect(result.usage['mistral-small-latest'].total).toBe(1500000);
+      expect(result.totals.input).toBe(1000000);
+      expect(result.totals.output).toBe(500000);
+      expect(result.totals.total).toBe(1500000);
     });
   });
 
@@ -49,8 +56,12 @@ describe('CostTrackerService', () => {
       const costs = service.getMonthlyCosts();
       const usage = service.getTokenUsage();
 
-      expect(costs).toEqual({});
-      expect(usage).toEqual({});
+      expect(costs.costs).toEqual({});
+      expect(costs.total).toBe(0);
+      expect(usage.usage).toEqual({});
+      expect(usage.totals.input).toBe(0);
+      expect(usage.totals.output).toBe(0);
+      expect(usage.totals.total).toBe(0);
     });
   });
 });

--- a/src/events/infrastructure/llm/cost-tracker.service.spec.ts
+++ b/src/events/infrastructure/llm/cost-tracker.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CostTrackerService } from './cost-tracker.service';
+
+describe('CostTrackerService', () => {
+  let service: CostTrackerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CostTrackerService],
+    }).compile();
+
+    service = module.get<CostTrackerService>(CostTrackerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('trackUsage', () => {
+    it('should track costs for mistral-small-latest', () => {
+      service.trackUsage('mistral-small-latest', 1000000, 500000);
+
+      const costs = service.getMonthlyCosts();
+      expect(costs['mistral-small-latest']).toBeCloseTo(0.175, 3); // (1M * 0.075) + (0.5M * 0.2)
+    });
+
+    it('should accumulate costs', () => {
+      service.trackUsage('mistral-small-latest', 1000000, 500000);
+      service.trackUsage('mistral-small-latest', 1000000, 500000);
+
+      const costs = service.getMonthlyCosts();
+      expect(costs['mistral-small-latest']).toBeCloseTo(0.35, 3);
+    });
+
+    it('should track token usage', () => {
+      service.trackUsage('mistral-small-latest', 1000000, 500000);
+
+      const usage = service.getTokenUsage();
+      expect(usage['mistral-small-latest'].input).toBe(1000000);
+      expect(usage['mistral-small-latest'].output).toBe(500000);
+    });
+  });
+
+  describe('resetMonthlyCosts', () => {
+    it('should reset costs and token usage', () => {
+      service.trackUsage('mistral-small-latest', 1000000, 500000);
+      service.resetMonthlyCosts();
+
+      const costs = service.getMonthlyCosts();
+      const usage = service.getTokenUsage();
+
+      expect(costs).toEqual({});
+      expect(usage).toEqual({});
+    });
+  });
+});

--- a/src/events/infrastructure/llm/cost-tracker.service.ts
+++ b/src/events/infrastructure/llm/cost-tracker.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Tracking-Service für LLM-API-Kosten
+ * Verfolgt Token-Verbrauch und berechnet Kosten basierend auf Modell-Pricing
+ */
+@Injectable()
+export class CostTrackerService {
+  private readonly logger = new Logger(CostTrackerService.name);
+  private costs: Map<string, number> = new Map();
+  private tokenUsage: Map<string, { input: number; output: number }> = new Map();
+
+  private readonly MODEL_PRICING: Record<string, { input: number; output: number }> = {
+    'mistral-small-latest': { input: 0.075, output: 0.2 },
+    'mistral-small-2409': { input: 0.075, output: 0.2 },
+    'gemini-2.0-flash': { input: 0.1, output: 0.4 },
+    'deepseek-chat': { input: 0.27, output: 1.1 },
+  };
+
+  /**
+   * Verfolgt Token-Verbrauch und berechnet Kosten
+   * @param model - Modell-Name
+   * @param inputTokens - Anzahl Input-Tokens
+   * @param outputTokens - Anzahl Output-Tokens
+   */
+  trackUsage(model: string, inputTokens: number, outputTokens: number): void {
+    const pricing = this.MODEL_PRICING[model];
+    if (!pricing) {
+      this.logger.warn(`Keine Pricing-Information für Modell: ${model}`);
+      return;
+    }
+
+    const cost =
+      (inputTokens / 1_000_000) * pricing.input + (outputTokens / 1_000_000) * pricing.output;
+
+    const current = this.costs.get(model) || 0;
+    this.costs.set(model, current + cost);
+
+    const currentUsage = this.tokenUsage.get(model) || { input: 0, output: 0 };
+    this.tokenUsage.set(model, {
+      input: currentUsage.input + inputTokens,
+      output: currentUsage.output + outputTokens,
+    });
+
+    this.logger.log(
+      `${model}: +$${cost.toFixed(4)} (Input: ${inputTokens}, Output: ${outputTokens}, Gesamt: $${(current + cost).toFixed(2)})`,
+    );
+  }
+
+  /**
+   * Gibt monatliche Kosten zurück
+   * @returns Kosten pro Modell
+   */
+  getMonthlyCosts(): Record<string, number> {
+    return Object.fromEntries(this.costs);
+  }
+
+  /**
+   * Gibt Token-Verbrauch zurück
+   * @returns Token-Verbrauch pro Modell
+   */
+  getTokenUsage(): Record<string, { input: number; output: number }> {
+    return Object.fromEntries(this.tokenUsage);
+  }
+
+  /**
+   * Setzt monatliche Kosten zurück
+   */
+  resetMonthlyCosts(): void {
+    this.costs.clear();
+    this.tokenUsage.clear();
+    this.logger.log('Monatliche Kosten zurückgesetzt');
+  }
+}

--- a/src/events/infrastructure/llm/cost-tracker.service.ts
+++ b/src/events/infrastructure/llm/cost-tracker.service.ts
@@ -49,18 +49,55 @@ export class CostTrackerService {
 
   /**
    * Gibt monatliche Kosten zurück
-   * @returns Kosten pro Modell
+   * @returns Kosten pro Modell mit Gesamtsumme
    */
-  getMonthlyCosts(): Record<string, number> {
-    return Object.fromEntries(this.costs);
+  getMonthlyCosts(): {
+    costs: Record<string, number>;
+    total: number;
+    currency: string;
+  } {
+    const costs = Object.fromEntries(this.costs);
+    const total = Array.from(this.costs.values()).reduce((sum, cost) => sum + cost, 0);
+
+    return {
+      costs,
+      total: Number(total.toFixed(4)),
+      currency: 'USD',
+    };
   }
 
   /**
    * Gibt Token-Verbrauch zurück
-   * @returns Token-Verbrauch pro Modell
+   * @returns Token-Verbrauch pro Modell mit Gesamtsummen
    */
-  getTokenUsage(): Record<string, { input: number; output: number }> {
-    return Object.fromEntries(this.tokenUsage);
+  getTokenUsage(): {
+    usage: Record<string, { input: number; output: number; total: number }>;
+    totals: { input: number; output: number; total: number };
+  } {
+    const usage: Record<string, { input: number; output: number; total: number }> = {};
+
+    let totalInput = 0;
+    let totalOutput = 0;
+
+    for (const [model, tokens] of this.tokenUsage.entries()) {
+      const total = tokens.input + tokens.output;
+      usage[model] = {
+        input: tokens.input,
+        output: tokens.output,
+        total,
+      };
+      totalInput += tokens.input;
+      totalOutput += tokens.output;
+    }
+
+    return {
+      usage,
+      totals: {
+        input: totalInput,
+        output: totalOutput,
+        total: totalInput + totalOutput,
+      },
+    };
   }
 
   /**

--- a/src/events/infrastructure/llm/event-normalizer.service.spec.ts
+++ b/src/events/infrastructure/llm/event-normalizer.service.spec.ts
@@ -100,7 +100,8 @@ describe('EventNormalizerService', () => {
           price: 10,
           priceString: '10,00€',
           website: 'https://example.com',
-          titleImageUrl: 'https://example.com/image.jpg',
+          contactEmail: 'test@example.com',
+          contactPhone: '+49 123 456789',
         },
       ];
 
@@ -109,7 +110,10 @@ describe('EventNormalizerService', () => {
       expect(result[0].price).toBe(10);
       expect(result[0].priceString).toBe('10,00€');
       expect(result[0].website).toBe('https://example.com');
-      expect(result[0].titleImageUrl).toBe('https://example.com/image.jpg');
+      expect(result[0].contactEmail).toBe('test@example.com');
+      expect(result[0].contactPhone).toBe('+49 123 456789');
+      // titleImageUrl wird NICHT vom LLM extrahiert - Bilder werden vom System bereitgestellt
+      expect(result[0].titleImageUrl).toBeUndefined();
     });
   });
 });

--- a/src/events/infrastructure/llm/event-normalizer.service.spec.ts
+++ b/src/events/infrastructure/llm/event-normalizer.service.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventNormalizerService } from './event-normalizer.service';
+import { Event } from '../../interfaces/event.interface';
+
+describe('EventNormalizerService', () => {
+  let service: EventNormalizerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EventNormalizerService],
+    }).compile();
+
+    service = module.get<EventNormalizerService>(EventNormalizerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('normalize', () => {
+    it('should complete event with id and timestamps', async () => {
+      const partialEvents: Partial<Event>[] = [
+        {
+          title: 'Test Event',
+          description: 'Test Description',
+          location: { address: 'Test Address', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-10', from: '18:00', to: '20:00' }],
+          categoryId: 'konzert',
+        },
+      ];
+
+      const result = await service.normalize(partialEvents);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBeDefined();
+      expect(result[0].createdAt).toBeDefined();
+      expect(result[0].updatedAt).toBeDefined();
+      expect(result[0].title).toBe('Test Event');
+    });
+
+    it('should handle missing location', async () => {
+      const partialEvents: Partial<Event>[] = [
+        {
+          title: 'Test Event',
+          description: 'Test Description',
+          dailyTimeSlots: [{ date: '2026-01-10' }],
+          categoryId: 'konzert',
+        },
+      ];
+
+      const result = await service.normalize(partialEvents);
+
+      expect(result[0].location).toEqual({ address: '', latitude: 0, longitude: 0 });
+    });
+
+    it('should validate and fix dailyTimeSlots', async () => {
+      const partialEvents: Partial<Event>[] = [
+        {
+          title: 'Test Event',
+          description: 'Test Description',
+          location: { address: 'Test Address', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [
+            { date: '2026-01-10', from: '18:00', to: '20:00' },
+            { date: 'invalid-date', from: '18:00' }, // Should be filtered out
+          ],
+          categoryId: 'konzert',
+        },
+      ];
+
+      const result = await service.normalize(partialEvents);
+
+      expect(result[0].dailyTimeSlots).toHaveLength(1);
+      expect(result[0].dailyTimeSlots[0].date).toBe('2026-01-10');
+    });
+
+    it('should map invalid categoryId to default', async () => {
+      const partialEvents: Partial<Event>[] = [
+        {
+          title: 'Test Event',
+          description: 'Test Description',
+          location: { address: 'Test Address', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-10' }],
+          categoryId: 'invalid-category',
+        },
+      ];
+
+      const result = await service.normalize(partialEvents);
+
+      expect(result[0].categoryId).toBe('default');
+    });
+
+    it('should preserve optional fields', async () => {
+      const partialEvents: Partial<Event>[] = [
+        {
+          title: 'Test Event',
+          description: 'Test Description',
+          location: { address: 'Test Address', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-10' }],
+          categoryId: 'konzert',
+          price: 10,
+          priceString: '10,00€',
+          website: 'https://example.com',
+          titleImageUrl: 'https://example.com/image.jpg',
+        },
+      ];
+
+      const result = await service.normalize(partialEvents);
+
+      expect(result[0].price).toBe(10);
+      expect(result[0].priceString).toBe('10,00€');
+      expect(result[0].website).toBe('https://example.com');
+      expect(result[0].titleImageUrl).toBe('https://example.com/image.jpg');
+    });
+  });
+});

--- a/src/events/infrastructure/llm/event-normalizer.service.ts
+++ b/src/events/infrastructure/llm/event-normalizer.service.ts
@@ -1,0 +1,140 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Event, DailyTimeSlot } from '../../interfaces/event.interface';
+
+/**
+ * Normalisiert und vervollständigt Events aus LLM-Extraktion
+ * Ergänzt fehlende Felder (id, timestamps) und validiert Daten
+ */
+@Injectable()
+export class EventNormalizerService {
+  private readonly logger = new Logger(EventNormalizerService.name);
+
+  /**
+   * Normalisiert ein Array von Partial-Events zu vollständigen Events
+   * @param partialEvents - Events aus LLM-Extraktion (ohne id/timestamps)
+   * @returns Vollständige Events
+   */
+  async normalize(partialEvents: Partial<Event>[]): Promise<Event[]> {
+    return partialEvents.map(partial => this.completeEvent(partial));
+  }
+
+  /**
+   * Ergänzt fehlende Felder eines Events
+   * @param partial - Partielles Event
+   * @returns Vollständiges Event
+   */
+  private completeEvent(partial: Partial<Event>): Event {
+    const now = new Date().toISOString();
+
+    const event: Event = {
+      id: crypto.randomUUID(),
+      title: partial.title || '',
+      description: partial.description || '',
+      location: this.ensureLocationFormat(partial.location),
+      dailyTimeSlots: this.validateAndFixDailyTimeSlots(partial.dailyTimeSlots),
+      categoryId: this.mapCategoryId(partial.categoryId),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Optionale Felder hinzufügen falls vorhanden
+    if (partial.price !== undefined) {
+      event.price = partial.price;
+    }
+    if (partial.priceString) {
+      event.priceString = partial.priceString;
+    }
+    // titleImageUrl und imageUrls werden NICHT vom LLM gesetzt - Bilder werden vom System selbst bereitgestellt
+    if (partial.website) {
+      event.website = partial.website;
+    }
+    if (partial.contactEmail) {
+      event.contactEmail = partial.contactEmail;
+    }
+    if (partial.contactPhone) {
+      event.contactPhone = partial.contactPhone;
+    }
+    if (partial.socialMedia) {
+      event.socialMedia = partial.socialMedia;
+    }
+    if (partial.ticketsNeeded !== undefined) {
+      event.ticketsNeeded = partial.ticketsNeeded;
+    }
+    // isPromoted wird NICHT vom LLM gesetzt - diese Entscheidung liegt allein beim System
+
+    return event;
+  }
+
+  /**
+   * Validiert und korrigiert dailyTimeSlots
+   * @param slots - Time-Slots aus LLM
+   * @returns Validierte Time-Slots
+   */
+  private validateAndFixDailyTimeSlots(slots?: DailyTimeSlot[]): DailyTimeSlot[] {
+    if (!slots || slots.length === 0) {
+      return [];
+    }
+
+    return slots
+      .filter(slot => {
+        // Validiere ISO-Datum-Format
+        if (!slot.date || !/^\d{4}-\d{2}-\d{2}$/.test(slot.date)) {
+          this.logger.warn(`Ungültiges Datum in dailyTimeSlot: ${slot.date}`);
+          return false;
+        }
+        return true;
+      })
+      .map(slot => ({
+        date: slot.date,
+        from: slot.from && /^\d{2}:\d{2}$/.test(slot.from) ? slot.from : undefined,
+        to: slot.to && /^\d{2}:\d{2}$/.test(slot.to) ? slot.to : undefined,
+      }));
+  }
+
+  /**
+   * Sichert korrektes Location-Format
+   * @param location - Location aus LLM
+   * @returns Validierte Location
+   */
+  private ensureLocationFormat(location?: any): {
+    address: string;
+    latitude: number;
+    longitude: number;
+  } {
+    if (!location || typeof location !== 'object') {
+      return { address: '', latitude: 0, longitude: 0 };
+    }
+
+    return {
+      address: location.address || '',
+      latitude: typeof location.latitude === 'number' ? location.latitude : 0,
+      longitude: typeof location.longitude === 'number' ? location.longitude : 0,
+    };
+  }
+
+  /**
+   * Validiert und mappt categoryId
+   * @param categoryId - Kategorie-ID aus LLM
+   * @returns Validierte categoryId
+   */
+  private mapCategoryId(categoryId?: string): string {
+    if (!categoryId || typeof categoryId !== 'string') {
+      return 'default';
+    }
+
+    // Validiere bekannte Kategorien (kann später erweitert werden)
+    const validCategories = [
+      'konzert',
+      'party',
+      'theater',
+      'ausstellung',
+      'sport',
+      'kinder',
+      'sonstiges',
+      'default',
+    ];
+    const normalized = categoryId.toLowerCase().trim();
+
+    return validCategories.includes(normalized) ? normalized : 'default';
+  }
+}

--- a/src/events/infrastructure/llm/html-cleaner.spec.ts
+++ b/src/events/infrastructure/llm/html-cleaner.spec.ts
@@ -1,0 +1,67 @@
+import { HtmlCleaner } from './html-cleaner';
+
+describe('HtmlCleaner', () => {
+  describe('clean', () => {
+    it('should remove script tags', () => {
+      const html = '<html><head><script>console.log("test");</script></head><body>Content</body></html>';
+      const cleaned = HtmlCleaner.clean(html);
+      expect(cleaned).not.toContain('<script>');
+      expect(cleaned).not.toContain('console.log');
+    });
+
+    it('should remove style tags', () => {
+      const html = '<html><head><style>.test { color: red; }</style></head><body>Content</body></html>';
+      const cleaned = HtmlCleaner.clean(html);
+      expect(cleaned).not.toContain('<style>');
+      expect(cleaned).not.toContain('color: red');
+    });
+
+    it('should remove HTML comments', () => {
+      const html = '<html><!-- This is a comment --><body>Content</body></html>';
+      const cleaned = HtmlCleaner.clean(html);
+      expect(cleaned).not.toContain('<!--');
+      expect(cleaned).not.toContain('-->');
+    });
+
+    it('should remove header, footer, nav, aside tags', () => {
+      const html = '<html><header>Header</header><nav>Nav</nav><body>Content</body><footer>Footer</footer></html>';
+      const cleaned = HtmlCleaner.clean(html);
+      expect(cleaned).not.toContain('<header>');
+      expect(cleaned).not.toContain('<footer>');
+      expect(cleaned).not.toContain('<nav>');
+    });
+
+    it('should compress whitespace', () => {
+      const html = '<html>   <body>   Content   with   spaces   </body>   </html>';
+      const cleaned = HtmlCleaner.clean(html);
+      expect(cleaned).not.toContain('   ');
+    });
+
+    it('should keep relevant classes', () => {
+      const html = '<div class="event-title">Event</div><div class="irrelevant-class">Other</div>';
+      const cleaned = HtmlCleaner.clean(html);
+      expect(cleaned).toContain('event-title');
+    });
+  });
+
+  describe('extractMainContent', () => {
+    it('should extract main content', () => {
+      const html = '<html><body><main><div>Main Content</div></main><footer>Footer</footer></body></html>';
+      const cleaned = HtmlCleaner.extractMainContent(html);
+      expect(cleaned).toContain('Main Content');
+      expect(cleaned).not.toContain('Footer');
+    });
+
+    it('should extract article content', () => {
+      const html = '<html><body><article><div>Article Content</div></article></body></html>';
+      const cleaned = HtmlCleaner.extractMainContent(html);
+      expect(cleaned).toContain('Article Content');
+    });
+
+    it('should fallback to full HTML if no main/article found', () => {
+      const html = '<html><body><div>Content</div></body></html>';
+      const cleaned = HtmlCleaner.extractMainContent(html);
+      expect(cleaned).toContain('Content');
+    });
+  });
+});

--- a/src/events/infrastructure/llm/html-cleaner.ts
+++ b/src/events/infrastructure/llm/html-cleaner.ts
@@ -1,0 +1,67 @@
+/**
+ * Utility-Klasse für HTML-Bereinigung vor LLM-Verarbeitung
+ * Reduziert Token-Verbrauch um 60-80% durch Entfernung irrelevanter Inhalte
+ */
+export class HtmlCleaner {
+  /**
+   * Bereinigt HTML für LLM-Verarbeitung
+   * Entfernt Scripts, Styles, Kommentare und komprimiert Whitespace
+   * @param html - Rohes HTML
+   * @returns Bereinigtes HTML
+   */
+  static clean(html: string): string {
+    let cleaned = html;
+
+    // 1. Entferne Script und Style Tags
+    cleaned = cleaned.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+    cleaned = cleaned.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
+
+    // 2. Entferne HTML-Kommentare
+    cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, '');
+
+    // 3. Entferne irrelevante Bereiche
+    cleaned = cleaned.replace(/<(header|footer|nav|aside|noscript)[^>]*>[\s\S]*?<\/\1>/gi, '');
+
+    // 4. Entferne Data-Attribute und Event-Handler
+    cleaned = cleaned.replace(/\s(data-[a-z-]+|on[a-z]+)="[^"]*"/gi, '');
+
+    // 5. Entferne leere Tags
+    cleaned = cleaned.replace(/<(\w+)[^>]*>\s*<\/\1>/g, '');
+
+    // 6. Komprimiere Whitespace
+    cleaned = cleaned.replace(/\s+/g, ' ');
+
+    // 7. Entferne übermäßige Attribute
+    cleaned = cleaned.replace(/\s(class|id|style)="[^"]*"/gi, (match, attr) => {
+      // Behalte nur relevante Klassen
+      if (attr === 'class' && /event|date|time|title|location|price/i.test(match)) {
+        return match;
+      }
+      return '';
+    });
+
+    return cleaned.trim();
+  }
+
+  /**
+   * Extrahiert nur den relevanten Content-Bereich
+   * Versucht main, article oder content div zu finden
+   * @param html - Rohes HTML
+   * @returns Bereinigter Hauptinhalt
+   */
+  static extractMainContent(html: string): string {
+    // Versuche main, article oder content div zu finden
+    const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+    if (mainMatch) {
+      return this.clean(mainMatch[1]);
+    }
+
+    const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+    if (articleMatch) {
+      return this.clean(articleMatch[1]);
+    }
+
+    // Fallback: Gesamtes HTML bereinigen
+    return this.clean(html);
+  }
+}

--- a/src/events/infrastructure/llm/hybrid-extractor.integration.spec.ts
+++ b/src/events/infrastructure/llm/hybrid-extractor.integration.spec.ts
@@ -2,7 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HybridExtractorService } from './hybrid-extractor.service';
 import { MistralExtractorService } from './mistral-extractor.service';
 import { EventNormalizerService } from './event-normalizer.service';
+import { CostTrackerService } from './cost-tracker.service';
 import { ScraperService } from '../scraping/scraper.service';
+import { EventFinderScraper } from '../scraping/eventfinder-scraper';
+import { CurtScraper } from '../scraping/curt-scraper';
+import { RausgegangenScraper } from '../scraping/rausgegangen-scraper';
+import { ParksScraper } from '../scraping/parks-scraper';
+import { EventbriteScraper } from '../scraping/eventbrite-scraper';
 import { PuppeteerManager } from '../scraping/puppeteer.config';
 import { Event } from '../../interfaces/event.interface';
 
@@ -14,13 +20,40 @@ describe('HybridExtractorService Integration', () => {
   let eventNormalizer: EventNormalizerService;
   let scraperService: ScraperService;
 
+  const mockScraper = {
+    scrapeEventsForDate: jest.fn(),
+    scrapeEventsForDateRange: jest.fn(),
+    scrapeEventsFromUrl: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         HybridExtractorService,
         MistralExtractorService,
         EventNormalizerService,
+        CostTrackerService,
         ScraperService,
+        {
+          provide: EventFinderScraper,
+          useValue: mockScraper,
+        },
+        {
+          provide: CurtScraper,
+          useValue: mockScraper,
+        },
+        {
+          provide: RausgegangenScraper,
+          useValue: mockScraper,
+        },
+        {
+          provide: ParksScraper,
+          useValue: mockScraper,
+        },
+        {
+          provide: EventbriteScraper,
+          useValue: mockScraper,
+        },
       ],
     }).compile();
 

--- a/src/events/infrastructure/llm/hybrid-extractor.integration.spec.ts
+++ b/src/events/infrastructure/llm/hybrid-extractor.integration.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HybridExtractorService } from './hybrid-extractor.service';
+import { MistralExtractorService } from './mistral-extractor.service';
+import { EventNormalizerService } from './event-normalizer.service';
+import { ScraperService } from '../scraping/scraper.service';
+import { PuppeteerManager } from '../scraping/puppeteer.config';
+import { Event } from '../../interfaces/event.interface';
+
+jest.mock('../scraping/puppeteer.config');
+
+describe('HybridExtractorService Integration', () => {
+  let service: HybridExtractorService;
+  let mistralExtractor: MistralExtractorService;
+  let eventNormalizer: EventNormalizerService;
+  let scraperService: ScraperService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HybridExtractorService,
+        MistralExtractorService,
+        EventNormalizerService,
+        ScraperService,
+      ],
+    }).compile();
+
+    service = module.get<HybridExtractorService>(HybridExtractorService);
+    mistralExtractor = module.get<MistralExtractorService>(MistralExtractorService);
+    eventNormalizer = module.get<EventNormalizerService>(EventNormalizerService);
+    scraperService = module.get<ScraperService>(ScraperService);
+
+    // Mock PuppeteerManager
+    (PuppeteerManager.getInstance as jest.Mock).mockReturnValue({
+      getPage: jest.fn().mockResolvedValue({
+        goto: jest.fn().mockResolvedValue(undefined),
+        content: jest.fn().mockResolvedValue('<html><body><main><div class="event">Test Event</div></main></body></html>'),
+        close: jest.fn().mockResolvedValue(undefined),
+      }),
+      getConfig: jest.fn().mockReturnValue({ timeout: 60000 }),
+    });
+  });
+
+  describe('End-to-End Scraping Flow', () => {
+    it('should complete full flow: URL → HTML → Mistral → Normalization → Events', async () => {
+      // Mock Mistral response
+      jest.spyOn(mistralExtractor, 'extractEvents').mockResolvedValue([
+        {
+          title: 'Integration Test Event',
+          description: 'Test Description',
+          location: { address: 'Test Address 123', latitude: 49.45, longitude: 11.08 },
+          dailyTimeSlots: [{ date: '2026-01-15', from: '19:00', to: '22:00' }],
+          categoryId: 'konzert',
+          price: 15,
+          priceString: '15,00€',
+        },
+      ]);
+
+      const result = await service.scrapeEventsFromUrl('https://example.com/events');
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].title).toBe('Integration Test Event');
+      expect(result.events[0].id).toBeDefined();
+      expect(result.events[0].createdAt).toBeDefined();
+      expect(result.events[0].updatedAt).toBeDefined();
+      expect(result.events[0].dailyTimeSlots).toHaveLength(1);
+      expect(result.events[0].dailyTimeSlots[0].date).toBe('2026-01-15');
+    });
+
+    it('should handle fallback scenario: Mistral fails → Puppeteer succeeds', async () => {
+      // Mock Mistral failure
+      jest.spyOn(mistralExtractor, 'extractEvents').mockRejectedValue(new Error('API Error'));
+
+      // Mock Puppeteer success
+      const fallbackEvents: Event[] = [
+        {
+          id: 'fallback-id',
+          title: 'Fallback Event',
+          description: 'Fallback Description',
+          location: { address: 'Fallback Address', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-15' }],
+          categoryId: 'default',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+
+      jest.spyOn(scraperService, 'scrapeEventsFromUrl').mockResolvedValue(fallbackEvents);
+
+      const result = await service.scrapeEventsFromUrl('https://eventfinder.de/nuernberg');
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].title).toBe('Fallback Event');
+      expect(scraperService.scrapeEventsFromUrl).toHaveBeenCalled();
+    });
+
+    it('should handle empty Mistral results → fallback to Puppeteer', async () => {
+      // Mock empty Mistral response
+      jest.spyOn(mistralExtractor, 'extractEvents').mockResolvedValue([]);
+
+      // Mock Puppeteer success
+      const fallbackEvents: Event[] = [
+        {
+          id: 'fallback-id',
+          title: 'Puppeteer Event',
+          description: 'Puppeteer Description',
+          location: { address: 'Puppeteer Address', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-15' }],
+          categoryId: 'default',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+
+      jest.spyOn(scraperService, 'scrapeEventsFromUrl').mockResolvedValue(fallbackEvents);
+
+      const result = await service.scrapeEventsFromUrl('https://curt.de/termine/84');
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].title).toBe('Puppeteer Event');
+    });
+  });
+});

--- a/src/events/infrastructure/llm/hybrid-extractor.service.spec.ts
+++ b/src/events/infrastructure/llm/hybrid-extractor.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HybridExtractorService } from './hybrid-extractor.service';
+import { MistralExtractorService } from './mistral-extractor.service';
+import { EventNormalizerService } from './event-normalizer.service';
+import { ScraperService } from '../scraping/scraper.service';
+import { PuppeteerManager } from '../scraping/puppeteer.config';
+import { ScraperResult } from '../scraping/base-scraper.interface';
+import { Event } from '../../interfaces/event.interface';
+
+jest.mock('../scraping/puppeteer.config');
+
+describe('HybridExtractorService', () => {
+  let service: HybridExtractorService;
+  let mistralExtractor: jest.Mocked<MistralExtractorService>;
+  let eventNormalizer: jest.Mocked<EventNormalizerService>;
+  let scraperService: jest.Mocked<ScraperService>;
+
+  beforeEach(async () => {
+    const mockMistralExtractor = {
+      extractEvents: jest.fn(),
+    };
+
+    const mockEventNormalizer = {
+      normalize: jest.fn(),
+    };
+
+    const mockScraperService = {
+      scrapeEventsFromUrl: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HybridExtractorService,
+        {
+          provide: MistralExtractorService,
+          useValue: mockMistralExtractor,
+        },
+        {
+          provide: EventNormalizerService,
+          useValue: mockEventNormalizer,
+        },
+        {
+          provide: ScraperService,
+          useValue: mockScraperService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<HybridExtractorService>(HybridExtractorService);
+    mistralExtractor = module.get(MistralExtractorService);
+    eventNormalizer = module.get(EventNormalizerService);
+    scraperService = module.get(ScraperService);
+
+    // Mock PuppeteerManager
+    (PuppeteerManager.getInstance as jest.Mock).mockReturnValue({
+      getPage: jest.fn().mockResolvedValue({
+        goto: jest.fn().mockResolvedValue(undefined),
+        content: jest.fn().mockResolvedValue('<html><body>Test</body></html>'),
+        close: jest.fn().mockResolvedValue(undefined),
+      }),
+      getConfig: jest.fn().mockReturnValue({ timeout: 60000 }),
+    });
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('scrapeEventsFromUrl', () => {
+    it('should use Mistral extraction successfully', async () => {
+      const mockEvents: Partial<Event>[] = [
+        {
+          title: 'Test Event',
+          description: 'Test',
+          location: { address: 'Test', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-10' }],
+          categoryId: 'konzert',
+        },
+      ];
+
+      const normalizedEvents: Event[] = [
+        {
+          id: 'test-id',
+          title: 'Test Event',
+          description: 'Test',
+          location: { address: 'Test', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-10' }],
+          categoryId: 'konzert',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+
+      mistralExtractor.extractEvents.mockResolvedValue(mockEvents);
+      eventNormalizer.normalize.mockResolvedValue(normalizedEvents);
+
+      const result = await service.scrapeEventsFromUrl('https://example.com/events');
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].title).toBe('Test Event');
+      expect(mistralExtractor.extractEvents).toHaveBeenCalled();
+      expect(scraperService.scrapeEventsFromUrl).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to Puppeteer on Mistral failure', async () => {
+      const fallbackEvents: Event[] = [
+        {
+          id: 'fallback-id',
+          title: 'Fallback Event',
+          description: 'Fallback',
+          location: { address: 'Fallback', latitude: 0, longitude: 0 },
+          dailyTimeSlots: [{ date: '2026-01-10' }],
+          categoryId: 'default',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+
+      mistralExtractor.extractEvents.mockRejectedValue(new Error('Mistral failed'));
+      scraperService.scrapeEventsFromUrl.mockResolvedValue(fallbackEvents);
+
+      const result = await service.scrapeEventsFromUrl('https://eventfinder.de/nuernberg');
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].title).toBe('Fallback Event');
+      expect(scraperService.scrapeEventsFromUrl).toHaveBeenCalled();
+    });
+
+    it('should fallback to Puppeteer on empty results', async () => {
+      mistralExtractor.extractEvents.mockResolvedValue([]);
+      scraperService.scrapeEventsFromUrl.mockResolvedValue([]);
+
+      const result = await service.scrapeEventsFromUrl('https://eventfinder.de/nuernberg');
+
+      expect(result.events).toHaveLength(0);
+      expect(scraperService.scrapeEventsFromUrl).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/events/infrastructure/llm/hybrid-extractor.service.ts
+++ b/src/events/infrastructure/llm/hybrid-extractor.service.ts
@@ -50,27 +50,99 @@ export class HybridExtractorService implements BaseScraper {
    */
   async scrapeEventsFromUrl(url: string, options?: ScraperOptions): Promise<ScraperResult> {
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:51',message:'scrapeEventsFromUrl entry',data:{url,useFallback:(options as any)?.useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:51',
+        message: 'scrapeEventsFromUrl entry',
+        data: { url, useFallback: (options as any)?.useFallback },
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H1',
+      }),
+    }).catch(() => {});
     // #endregion
     const useFallback = (options as any)?.useFallback !== false;
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:53',message:'useFallback determined',data:{useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:53',
+        message: 'useFallback determined',
+        data: { useFallback },
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H1',
+      }),
+    }).catch(() => {});
     // #endregion
     try {
       // Versuche Mistral-Extraktion
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:56',message:'before fetchHtml',data:{url},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:56',
+          message: 'before fetchHtml',
+          data: { url },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H2',
+        }),
+      }).catch(() => {});
       // #endregion
       const html = await this.fetchHtml(url);
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:58',message:'after fetchHtml',data:{htmlLength:html.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:58',
+          message: 'after fetchHtml',
+          data: { htmlLength: html.length },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H2',
+        }),
+      }).catch(() => {});
       // #endregion
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:60',message:'before tryMistralExtraction',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:60',
+          message: 'before tryMistralExtraction',
+          data: {},
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3',
+        }),
+      }).catch(() => {});
       // #endregion
       const events = await this.tryMistralExtraction(html);
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:62',message:'after tryMistralExtraction',data:{eventsCount:events?.length||0,eventsIsNull:events===null},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3,H4'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:62',
+          message: 'after tryMistralExtraction',
+          data: { eventsCount: events?.length || 0, eventsIsNull: events === null },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3,H4',
+        }),
+      }).catch(() => {});
       // #endregion
 
       if (events && events.length > 0) {
@@ -81,11 +153,35 @@ export class HybridExtractorService implements BaseScraper {
         };
       }
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:70',message:'empty events, checking fallback',data:{useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H4'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:70',
+          message: 'empty events, checking fallback',
+          data: { useFallback },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H4',
+        }),
+      }).catch(() => {});
       // #endregion
     } catch (error) {
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:72',message:'catch block',data:{errorMessage:error.message,useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3,H5'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:72',
+          message: 'catch block',
+          data: { errorMessage: error.message, useFallback },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3,H5',
+        }),
+      }).catch(() => {});
       // #endregion
       this.logger.warn(`Mistral-Extraktion fehlgeschlagen: ${error.message}`);
     }
@@ -93,7 +189,19 @@ export class HybridExtractorService implements BaseScraper {
     // Fallback zu Puppeteer-Scraper nur wenn erlaubt
     if (!useFallback) {
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:78',message:'useFallback=false, returning empty',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:78',
+          message: 'useFallback=false, returning empty',
+          data: {},
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H1',
+        }),
+      }).catch(() => {});
       // #endregion
       return {
         events: [],
@@ -102,7 +210,19 @@ export class HybridExtractorService implements BaseScraper {
     }
 
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:85',message:'calling fallbackToPuppeteer',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:85',
+        message: 'calling fallbackToPuppeteer',
+        data: {},
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H1',
+      }),
+    }).catch(() => {});
     // #endregion
     this.logger.log('Fallback zu Puppeteer-Scraper');
     return this.fallbackToPuppeteer(url);
@@ -115,34 +235,118 @@ export class HybridExtractorService implements BaseScraper {
    */
   private async tryMistralExtraction(html: string): Promise<Event[] | null> {
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:95',message:'tryMistralExtraction entry',data:{htmlLength:html.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:95',
+        message: 'tryMistralExtraction entry',
+        data: { htmlLength: html.length },
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H3',
+      }),
+    }).catch(() => {});
     // #endregion
     try {
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:98',message:'before mistralExtractor.extractEvents',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:98',
+          message: 'before mistralExtractor.extractEvents',
+          data: {},
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3',
+        }),
+      }).catch(() => {});
       // #endregion
       const partialEvents = await this.mistralExtractor.extractEvents(html);
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:100',message:'after mistralExtractor.extractEvents',data:{partialEventsCount:partialEvents?.length||0},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:100',
+          message: 'after mistralExtractor.extractEvents',
+          data: { partialEventsCount: partialEvents?.length || 0 },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3',
+        }),
+      }).catch(() => {});
       // #endregion
       if (!partialEvents || partialEvents.length === 0) {
         // #region agent log
-        fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:102',message:'empty partialEvents, returning null',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H4'})}).catch(()=>{});
+        fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            location: 'hybrid-extractor.service.ts:102',
+            message: 'empty partialEvents, returning null',
+            data: {},
+            timestamp: Date.now(),
+            sessionId: 'debug-session',
+            runId: 'run1',
+            hypothesisId: 'H4',
+          }),
+        }).catch(() => {});
         // #endregion
         return null;
       }
 
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:107',message:'before eventNormalizer.normalize',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:107',
+          message: 'before eventNormalizer.normalize',
+          data: {},
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3',
+        }),
+      }).catch(() => {});
       // #endregion
       const normalizedEvents = await this.eventNormalizer.normalize(partialEvents);
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:109',message:'after eventNormalizer.normalize',data:{normalizedEventsCount:normalizedEvents?.length||0},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:109',
+          message: 'after eventNormalizer.normalize',
+          data: { normalizedEventsCount: normalizedEvents?.length || 0 },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3',
+        }),
+      }).catch(() => {});
       // #endregion
       return normalizedEvents;
     } catch (error) {
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:112',message:'tryMistralExtraction catch',data:{errorMessage:error.message,errorStack:error.stack},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:112',
+          message: 'tryMistralExtraction catch',
+          data: { errorMessage: error.message, errorStack: error.stack },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H3',
+        }),
+      }).catch(() => {});
       // #endregion
       this.logger.error(`Fehler bei Mistral-Extraktion: ${error.message}`);
       return null;
@@ -193,15 +397,51 @@ export class HybridExtractorService implements BaseScraper {
    */
   private async fetchHtml(url: string): Promise<string> {
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:152',message:'fetchHtml entry - using Puppeteer',data:{url},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:152',
+        message: 'fetchHtml entry - using Puppeteer',
+        data: { url },
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H2',
+      }),
+    }).catch(() => {});
     // #endregion
     const puppeteerManager = PuppeteerManager.getInstance();
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:155',message:'before getPage',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:155',
+        message: 'before getPage',
+        data: {},
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H2,H5',
+      }),
+    }).catch(() => {});
     // #endregion
     const page = await puppeteerManager.getPage();
     // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:157',message:'after getPage, before goto',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        location: 'hybrid-extractor.service.ts:157',
+        message: 'after getPage, before goto',
+        data: {},
+        timestamp: Date.now(),
+        sessionId: 'debug-session',
+        runId: 'run1',
+        hypothesisId: 'H2,H5',
+      }),
+    }).catch(() => {});
     // #endregion
 
     try {
@@ -210,12 +450,36 @@ export class HybridExtractorService implements BaseScraper {
         timeout: puppeteerManager.getConfig().timeout,
       });
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:164',message:'after goto, before content',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:164',
+          message: 'after goto, before content',
+          data: {},
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H2,H5',
+        }),
+      }).catch(() => {});
       // #endregion
 
       const html = await page.content();
       // #region agent log
-      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:168',message:'after content',data:{htmlLength:html.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          location: 'hybrid-extractor.service.ts:168',
+          message: 'after content',
+          data: { htmlLength: html.length },
+          timestamp: Date.now(),
+          sessionId: 'debug-session',
+          runId: 'run1',
+          hypothesisId: 'H2,H5',
+        }),
+      }).catch(() => {});
       // #endregion
       return html;
     } finally {

--- a/src/events/infrastructure/llm/hybrid-extractor.service.ts
+++ b/src/events/infrastructure/llm/hybrid-extractor.service.ts
@@ -1,0 +1,257 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  BaseScraper,
+  ScraperOptions,
+  ScraperResult,
+  ScraperConfig,
+  ScraperType,
+} from '../scraping/base-scraper.interface';
+import { MistralExtractorService } from './mistral-extractor.service';
+import { EventNormalizerService } from './event-normalizer.service';
+import { ScraperService } from '../scraping/scraper.service';
+import { PuppeteerManager } from '../scraping/puppeteer.config';
+import { Event } from '../../interfaces/event.interface';
+
+/**
+ * Hybrid-Extractor kombiniert LLM-basierte Extraktion mit Puppeteer-Fallback
+ * Strategie: Mistral → Puppeteer-Scraper
+ */
+@Injectable()
+export class HybridExtractorService implements BaseScraper {
+  private readonly logger = new Logger(HybridExtractorService.name);
+  private config: ScraperConfig;
+
+  constructor(
+    private readonly mistralExtractor: MistralExtractorService,
+    private readonly eventNormalizer: EventNormalizerService,
+    private readonly scraperService: ScraperService,
+  ) {
+    this.config = {
+      baseUrl: '',
+      dateFormat: 'YYYY-MM-DD',
+    };
+  }
+
+  initialize(config: ScraperConfig): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  validateConfig(): boolean {
+    return true; // Keine spezifische Konfiguration nötig
+  }
+
+  async handleCookieBanner?(page: any): Promise<void> {
+    // Nicht benötigt für LLM-Extraktion, wird von Puppeteer-Fallback gehandhabt
+  }
+
+  /**
+   * Hauptmethode: Extrahiert Events von einer URL
+   * Versucht zuerst Mistral, dann Fallback zu Puppeteer
+   */
+  async scrapeEventsFromUrl(url: string, options?: ScraperOptions): Promise<ScraperResult> {
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:51',message:'scrapeEventsFromUrl entry',data:{url,useFallback:(options as any)?.useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    // #endregion
+    const useFallback = (options as any)?.useFallback !== false;
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:53',message:'useFallback determined',data:{useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    // #endregion
+    try {
+      // Versuche Mistral-Extraktion
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:56',message:'before fetchHtml',data:{url},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
+      // #endregion
+      const html = await this.fetchHtml(url);
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:58',message:'after fetchHtml',data:{htmlLength:html.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
+      // #endregion
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:60',message:'before tryMistralExtraction',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      // #endregion
+      const events = await this.tryMistralExtraction(html);
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:62',message:'after tryMistralExtraction',data:{eventsCount:events?.length||0,eventsIsNull:events===null},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3,H4'})}).catch(()=>{});
+      // #endregion
+
+      if (events && events.length > 0) {
+        this.logger.log(`Mistral-Extraktion erfolgreich: ${events.length} Events gefunden`);
+        return {
+          events,
+          hasMorePages: false,
+        };
+      }
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:70',message:'empty events, checking fallback',data:{useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H4'})}).catch(()=>{});
+      // #endregion
+    } catch (error) {
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:72',message:'catch block',data:{errorMessage:error.message,useFallback},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3,H5'})}).catch(()=>{});
+      // #endregion
+      this.logger.warn(`Mistral-Extraktion fehlgeschlagen: ${error.message}`);
+    }
+
+    // Fallback zu Puppeteer-Scraper nur wenn erlaubt
+    if (!useFallback) {
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:78',message:'useFallback=false, returning empty',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+      // #endregion
+      return {
+        events: [],
+        hasMorePages: false,
+      };
+    }
+
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:85',message:'calling fallbackToPuppeteer',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
+    // #endregion
+    this.logger.log('Fallback zu Puppeteer-Scraper');
+    return this.fallbackToPuppeteer(url);
+  }
+
+  /**
+   * Versucht Mistral-Extraktion
+   * @param html - HTML-Inhalt
+   * @returns Events oder null bei Fehler
+   */
+  private async tryMistralExtraction(html: string): Promise<Event[] | null> {
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:95',message:'tryMistralExtraction entry',data:{htmlLength:html.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+    // #endregion
+    try {
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:98',message:'before mistralExtractor.extractEvents',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      // #endregion
+      const partialEvents = await this.mistralExtractor.extractEvents(html);
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:100',message:'after mistralExtractor.extractEvents',data:{partialEventsCount:partialEvents?.length||0},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      // #endregion
+      if (!partialEvents || partialEvents.length === 0) {
+        // #region agent log
+        fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:102',message:'empty partialEvents, returning null',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H4'})}).catch(()=>{});
+        // #endregion
+        return null;
+      }
+
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:107',message:'before eventNormalizer.normalize',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      // #endregion
+      const normalizedEvents = await this.eventNormalizer.normalize(partialEvents);
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:109',message:'after eventNormalizer.normalize',data:{normalizedEventsCount:normalizedEvents?.length||0},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      // #endregion
+      return normalizedEvents;
+    } catch (error) {
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:112',message:'tryMistralExtraction catch',data:{errorMessage:error.message,errorStack:error.stack},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H3'})}).catch(()=>{});
+      // #endregion
+      this.logger.error(`Fehler bei Mistral-Extraktion: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Fallback zu bestehenden Puppeteer-Scrapers
+   * Versucht automatisch den passenden Scraper basierend auf der URL zu finden
+   */
+  private async fallbackToPuppeteer(url: string): Promise<ScraperResult> {
+    // Versuche Scraper basierend auf URL-Domain zu identifizieren
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+
+    // Mapping von Domain zu ScraperType
+    const domainToScraper: Record<string, ScraperType> = {
+      'eventfinder.de': ScraperType.EVENTFINDER,
+      'curt.de': ScraperType.CURT,
+      'rausgegangen.de': ScraperType.RAUSGEGANGEN,
+      'eventbrite.de': ScraperType.EVENTBRITE,
+      'eventbrite.com': ScraperType.EVENTBRITE,
+    };
+
+    const scraperType = domainToScraper[hostname];
+    if (scraperType) {
+      try {
+        const events = await this.scraperService.scrapeEventsFromUrl(scraperType, url);
+        return {
+          events,
+          hasMorePages: false,
+        };
+      } catch (error) {
+        this.logger.error(`Puppeteer-Scraper fehlgeschlagen: ${error.message}`);
+      }
+    }
+
+    // Wenn kein passender Scraper gefunden, leeres Ergebnis zurückgeben
+    this.logger.warn(`Kein passender Scraper für URL gefunden: ${url}`);
+    return {
+      events: [],
+      hasMorePages: false,
+    };
+  }
+
+  /**
+   * Holt HTML-Inhalt mit Puppeteer
+   */
+  private async fetchHtml(url: string): Promise<string> {
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:152',message:'fetchHtml entry - using Puppeteer',data:{url},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
+    // #endregion
+    const puppeteerManager = PuppeteerManager.getInstance();
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:155',message:'before getPage',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+    // #endregion
+    const page = await puppeteerManager.getPage();
+    // #region agent log
+    fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:157',message:'after getPage, before goto',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+    // #endregion
+
+    try {
+      await page.goto(url, {
+        waitUntil: 'networkidle0',
+        timeout: puppeteerManager.getConfig().timeout,
+      });
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:164',message:'after goto, before content',data:{},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+      // #endregion
+
+      const html = await page.content();
+      // #region agent log
+      fetch('http://127.0.0.1:7242/ingest/348fd923-c5d7-4f25-b5ad-db7afba331f0',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'hybrid-extractor.service.ts:168',message:'after content',data:{htmlLength:html.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'H2,H5'})}).catch(()=>{});
+      // #endregion
+      return html;
+    } finally {
+      await page.close();
+    }
+  }
+
+  // BaseScraper Interface-Implementierung (nicht alle Methoden werden verwendet)
+
+  async scrapeEvents(options: ScraperOptions): Promise<Event[]> {
+    if (options.startDate && options.endDate) {
+      return this.scrapeEventsForDateRange(options.startDate, options.endDate);
+    }
+    if (options.startDate) {
+      return this.scrapeEventsForDate(options.startDate);
+    }
+    throw new Error('URL oder Datum muss angegeben werden');
+  }
+
+  async scrapeEventsForDate(date: Date): Promise<Event[]> {
+    throw new Error('Nicht unterstützt - verwende scrapeEventsFromUrl');
+  }
+
+  async scrapeEventsForDateRange(startDate: Date, endDate: Date): Promise<Event[]> {
+    throw new Error('Nicht unterstützt - verwende scrapeEventsFromUrl');
+  }
+
+  extractDateFromUrl(url: string): Date | null {
+    return null; // Nicht relevant für LLM-Extraktion
+  }
+
+  generateUrlForDate(date: Date): string {
+    throw new Error('Nicht unterstützt');
+  }
+
+  generateUrl(options: ScraperOptions): string {
+    throw new Error('Nicht unterstützt');
+  }
+}

--- a/src/events/infrastructure/llm/interfaces/llm-extractor.interface.ts
+++ b/src/events/infrastructure/llm/interfaces/llm-extractor.interface.ts
@@ -1,0 +1,13 @@
+import { Event } from '../../../interfaces/event.interface';
+
+/**
+ * Interface für LLM-basierte Event-Extraktoren
+ */
+export interface LlmExtractor {
+  /**
+   * Extrahiert Events aus HTML-Inhalt
+   * @param html - Bereinigtes HTML
+   * @returns Array von Events (Partial<Event>, da id/timestamps später hinzugefügt werden)
+   */
+  extractEvents(html: string): Promise<Partial<Event>[]>;
+}

--- a/src/events/infrastructure/llm/mistral-extractor.service.spec.ts
+++ b/src/events/infrastructure/llm/mistral-extractor.service.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MistralExtractorService } from './mistral-extractor.service';
+import { CostTrackerService } from './cost-tracker.service';
+
+describe('MistralExtractorService', () => {
+  let service: MistralExtractorService;
+  let costTracker: CostTrackerService;
+  let mockCreate: jest.Mock;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MistralExtractorService, CostTrackerService],
+    }).compile();
+
+    service = module.get<MistralExtractorService>(MistralExtractorService);
+    costTracker = module.get<CostTrackerService>(CostTrackerService);
+
+    // Mock OpenAI Client create method
+    mockCreate = jest.fn();
+    (service as any).client = {
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    };
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('extractEvents', () => {
+    it('should extract events successfully', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                events: [
+                  {
+                    title: 'Test Event',
+                    description: 'Test Description',
+                    location: { address: 'Test Address', latitude: 0, longitude: 0 },
+                    dailyTimeSlots: [{ date: '2026-01-10', from: '18:00', to: '20:00' }],
+                    categoryId: 'konzert',
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 200,
+        },
+      };
+
+      mockCreate.mockResolvedValue(mockResponse as any);
+
+      const html = '<html><body><div class="event">Test Event</div></body></html>';
+      const result = await service.extractEvents(html);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('Test Event');
+      expect(mockCreate).toHaveBeenCalled();
+    });
+
+    it('should handle empty events array', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({ events: [] }),
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 500,
+          completion_tokens: 50,
+        },
+      };
+
+      mockCreate.mockResolvedValue(mockResponse as any);
+
+      const html = '<html><body>No events</body></html>';
+      const result = await service.extractEvents(html);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should throw error on API failure', async () => {
+      mockCreate.mockRejectedValue(new Error('API Error'));
+
+      const html = '<html><body>Content</body></html>';
+
+      await expect(service.extractEvents(html)).rejects.toThrow('API Error');
+    });
+
+    it('should throw error on empty response', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: null,
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 500,
+          completion_tokens: 0,
+        },
+      };
+
+      mockCreate.mockResolvedValue(mockResponse as any);
+
+      const html = '<html><body>Content</body></html>';
+
+      await expect(service.extractEvents(html)).rejects.toThrow('Keine Antwort von Mistral API erhalten');
+    });
+  });
+});

--- a/src/events/infrastructure/llm/mistral-extractor.service.ts
+++ b/src/events/infrastructure/llm/mistral-extractor.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, Logger } from '@nestjs/common';
+import OpenAI from 'openai';
+import { LlmExtractor } from './interfaces/llm-extractor.interface';
+import { Event } from '../../interfaces/event.interface';
+import { HtmlCleaner } from './html-cleaner';
+import { EVENT_EXTRACTION_SYSTEM_PROMPT } from './prompts/event-extraction.prompt';
+import { CostTrackerService } from './cost-tracker.service';
+
+/**
+ * Mistral-basierter Event-Extraktor
+ * Nutzt Mistral Small 3.2 für semantische Event-Extraktion aus HTML
+ */
+@Injectable()
+export class MistralExtractorService implements LlmExtractor {
+  private readonly logger = new Logger(MistralExtractorService.name);
+  private readonly client: OpenAI;
+
+  constructor(private readonly costTracker: CostTrackerService) {
+    // Mistral AI API nutzt OpenAI-kompatibles Format
+    // baseURL zeigt auf Mistral, nicht auf OpenAI
+    this.client = new OpenAI({
+      baseURL: process.env.MISTRAL_BASE_URL || 'https://api.mistral.ai/v1',
+      apiKey: process.env.MISTRAL_API_KEY || '',
+    });
+
+    if (!process.env.MISTRAL_API_KEY) {
+      this.logger.warn('MISTRAL_API_KEY nicht gesetzt. LLM-Extraktion wird nicht funktionieren.');
+    }
+  }
+
+  /**
+   * Extrahiert Events aus HTML-Inhalt
+   * @param html - Rohes HTML
+   * @returns Array von Events (Partial<Event>, ohne id/timestamps)
+   */
+  async extractEvents(html: string): Promise<Partial<Event>[]> {
+    const cleanedHtml = HtmlCleaner.extractMainContent(html);
+
+    try {
+      const response = await this.client.chat.completions.create({
+        model: 'mistral-small-latest',
+        messages: [
+          {
+            role: 'system',
+            content: EVENT_EXTRACTION_SYSTEM_PROMPT,
+          },
+          {
+            role: 'user',
+            content: `Extrahiere alle Events aus folgendem HTML:\n\n${cleanedHtml}`,
+          },
+        ],
+        response_format: { type: 'json_object' },
+        temperature: 0,
+      });
+
+      const content = response.choices[0]?.message?.content;
+      if (!content) {
+        throw new Error('Keine Antwort von Mistral API erhalten');
+      }
+
+      const parsed = JSON.parse(content);
+      const events = Array.isArray(parsed.events) ? parsed.events : [];
+
+      // Track Kosten
+      const usage = response.usage;
+      if (usage) {
+        this.costTracker.trackUsage(
+          'mistral-small-latest',
+          usage.prompt_tokens,
+          usage.completion_tokens,
+        );
+      }
+
+      this.logger.debug(`Mistral-Extraktion erfolgreich: ${events.length} Events gefunden`);
+
+      return events as Partial<Event>[];
+    } catch (error) {
+      this.logger.error(`Fehler bei Mistral-Extraktion: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/src/events/infrastructure/llm/prompts/event-extraction.prompt.ts
+++ b/src/events/infrastructure/llm/prompts/event-extraction.prompt.ts
@@ -1,0 +1,65 @@
+/**
+ * System-Prompt für Event-Extraktion aus HTML
+ * WICHTIG: Die Ausgabe muss dem Event-Interface entsprechen
+ */
+export const EVENT_EXTRACTION_SYSTEM_PROMPT = `
+Du bist ein Experte für die Extraktion von Veranstaltungsdaten aus HTML.
+
+AUFGABE:
+Analysiere das HTML und extrahiere ALLE erkennbaren Events/Veranstaltungen.
+
+WICHTIG: Die Ausgabe muss dem folgenden Event-Interface entsprechen:
+
+{
+  "events": [{
+    "title": "string (erforderlich)",
+    "description": "string",
+    "location": {
+      "address": "string (erforderlich)",
+      "latitude": "number (kann 0 sein wenn nicht verfügbar)",
+      "longitude": "number (kann 0 sein wenn nicht verfügbar)"
+    },
+    "dailyTimeSlots": [{
+      "date": "YYYY-MM-DD (erforderlich, ISO-Format)",
+      "from": "HH:mm (optional)",
+      "to": "HH:mm (optional)"
+    }],
+    "price": "number | null (0 für kostenlos, null wenn unbekannt)",
+    "priceString": "string (optional, z.B. 'ab 10,00€')",
+    "categoryId": "string (erforderlich, z.B. 'konzert', 'party', 'theater', 'default')",
+    "website": "string (optional, absolute URL)",
+    "contactEmail": "string (optional)",
+    "contactPhone": "string (optional)",
+    "socialMedia": {
+      "instagram": "string (optional)",
+      "facebook": "string (optional)",
+      "tiktok": "string (optional)"
+    },
+    "ticketsNeeded": "boolean (optional)"
+  }]
+}
+
+WICHTIG: 
+- Das Feld "isPromoted" wird NICHT extrahiert - diese Entscheidung liegt allein beim System.
+- Bild-URLs (titleImageUrl, imageUrls) werden NICHT extrahiert - Bilder werden vom System selbst bereitgestellt.
+
+REGELN:
+1. Extrahiere nur echte Events, keine Werbung oder Navigation
+2. Konvertiere deutsche Datumsformate zu ISO (YYYY-MM-DD)
+3. Füge fehlendes Jahr hinzu (aktuelles Jahr: ${new Date().getFullYear()})
+4. Zeiten im Format HH:mm
+5. Preise als Zahl in Euro (0 für kostenlos, null wenn unbekannt)
+6. Leere Felder als null, nicht als leere Strings
+7. Absolute URLs für Links verwenden (Bilder werden NICHT extrahiert)
+8. dailyTimeSlots muss mindestens einen Eintrag enthalten
+9. location.address ist erforderlich, latitude/longitude können 0 sein
+
+WICHTIGE HINWEISE:
+- "Eintritt frei", "kostenlos", "free" → price: 0
+- "ab X€", "X€ - Y€" → price: niedrigster Wert, priceString: Original
+- Bei Datumsbereich: Erstelle separate Einträge pro Tag
+- Kategorien: konzert, party, theater, ausstellung, sport, kinder, sonstiges, default
+- id, createdAt, updatedAt werden automatisch generiert (nicht im Output erwarten)
+
+Antworte NUR mit einem JSON-Objekt im Format: { "events": [...] }
+`;

--- a/src/events/infrastructure/llm/schemas/event-extraction.schema.ts
+++ b/src/events/infrastructure/llm/schemas/event-extraction.schema.ts
@@ -1,0 +1,58 @@
+/**
+ * JSON-Schema für Event-Extraktion
+ * Entspricht dem Event-Interface (ohne id, createdAt, updatedAt)
+ * Diese werden im EventNormalizer hinzugefügt
+ */
+export const EVENT_EXTRACTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    events: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          description: { type: 'string' },
+          location: {
+            type: 'object',
+            properties: {
+              address: { type: 'string' },
+              latitude: { type: 'number' },
+              longitude: { type: 'number' },
+            },
+            required: ['address'],
+          },
+          dailyTimeSlots: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                date: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$' },
+                from: { type: 'string', pattern: '^\\d{2}:\\d{2}$' },
+                to: { type: 'string', pattern: '^\\d{2}:\\d{2}$' },
+              },
+              required: ['date'],
+            },
+          },
+          price: { type: ['number', 'null'] },
+          priceString: { type: 'string' },
+          categoryId: { type: 'string' },
+          website: { type: 'string' },
+          contactEmail: { type: 'string' },
+          contactPhone: { type: 'string' },
+          socialMedia: {
+            type: 'object',
+            properties: {
+              instagram: { type: 'string' },
+              facebook: { type: 'string' },
+              tiktok: { type: 'string' },
+            },
+          },
+          ticketsNeeded: { type: 'boolean' },
+        },
+        required: ['title', 'location', 'dailyTimeSlots', 'categoryId'],
+      },
+    },
+  },
+  required: ['events'],
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { ValidationPipe, Logger } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { TimezoneInterceptor } from './core/interceptors/timezone.interceptor';
+import { useContainer } from 'class-validator';
 
 async function bootstrap() {
   // Log-Level basierend auf Umgebung konfigurieren
@@ -27,6 +28,9 @@ async function bootstrap() {
   });
 
   const configService = app.get(ConfigService);
+
+  // Enable class-validator to use NestJS's dependency injection container
+  useContainer(app.select(AppModule), { fallbackOnErrors: true });
 
   // Enable CORS
   const allowedOrigins: string[] = ['http://localhost:5173']; // Local Frontend Development


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an LLM-driven scraping path and supporting infra, replacing the legacy generic scrape endpoint.
> 
> - New endpoints: `POST /events/scrape/llm`, `GET /events/scrape/llm/costs`, `GET /events/scrape/llm/tokens` (LLM extraction, costs, token usage)
> - New services: `MistralExtractorService` (via `openai` client), `HybridExtractorService` (LLM → Puppeteer fallback), `EventNormalizerService`, `HtmlCleaner`, `CostTrackerService`
> - `EventsModule` wired with new providers; added `LlmScrapeDto`; `CreateEventDto` now validates `categoryId` via `IsValidCategory` (DI enabled with `useContainer` in `main.ts`)
> - Removed legacy `GET /events/scrape` endpoint and its tests
> - Config: add `MISTRAL_API_KEY`/`MISTRAL_BASE_URL` envs; update `docker-compose.yml`, README, and deployment commands
> - Docs: new `docs/api-llm-scraping.md`, `docs/mistral-api-setup.md`, and analysis `docs/scraping-analysis.md`
> - Dependencies: add `openai`; comprehensive unit/integration tests for LLM components
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b81290ebc30094f839ce5ffa425f7de1ea2102c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->